### PR TITLE
skeleton for basic database loadtesting

### DIFF
--- a/app/api/admin/loadtest/_common/utils.ts
+++ b/app/api/admin/loadtest/_common/utils.ts
@@ -1,0 +1,7 @@
+export function formatDuration(milliseconds: number): string {
+  const minutes = Math.floor((milliseconds / (1000 * 60)) % 60);
+  const seconds = Math.floor((milliseconds / 1000) % 60);
+  const ms = Math.floor(milliseconds % 1000);
+
+  return `${minutes > 0 ? minutes + "m" : ""}${seconds > 0 ? seconds + "s" : ""}${ms}ms`;
+}

--- a/app/api/admin/loadtest/create-users/route.ts
+++ b/app/api/admin/loadtest/create-users/route.ts
@@ -1,0 +1,71 @@
+import { requestWithAuthAdmin } from "@/app/api/_common/endpoints";
+import { SupabaseClient, User } from "@supabase/supabase-js";
+import { formatDuration } from "../_common/utils";
+
+type UserData = {
+  index: number,
+  name: string,
+  password: string,
+  email: string,
+  user: User | null,
+};
+
+async function createUser(supabase: SupabaseClient, verbose: boolean, user: UserData): Promise<UserData> {
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: user.email,
+    password: user.password,
+    email_confirm: true,
+  });
+  if (error) {
+    console.log(error);
+  } else {
+    if (verbose) {
+      console.log(`created user ${user.index}: ${data.user.email}`);
+    }
+    user.user = data.user;
+  }
+  return user;
+}
+export const GET = requestWithAuthAdmin(async (supabase, _profile, request, _body) => {
+  const numUsers = parseInt(request.nextUrl.searchParams.get("num_users") ?? "10");
+  const verbose = request.nextUrl.searchParams.get("verbose") == "true" || false;
+  const parallel = request.nextUrl.searchParams.get("parallel") == "true" || false;
+
+  const users: UserData[] = [];
+
+  console.log("initializing users...");
+  for (let i = 0; i < numUsers; i++) {
+    const userName = `${i}`;
+    const password = userName;
+    const email = `${userName}@load.test`
+    const user = {
+      index: i,
+      name: userName,
+      password: password,
+      email: email,
+      user: null,
+    };
+    users.push(user);
+  }
+
+  const startCreateTime = performance.now();
+  var createdUsers = [];
+  if (parallel) {
+    console.log("creating users in parallel...");
+    createdUsers = await Promise.all(users.map((user) => createUser(supabase, verbose, user)));
+  } else {
+    console.log("creating users sequentially...");
+    for (let user of users) {
+      createdUsers.push(await createUser(supabase, verbose, user));
+      if ((user.index + 1) % 10 == 0) {
+        console.log(`created ${user.index + 1} users`);
+      }
+    }
+  }
+  const finishCreateTime = performance.now();
+
+  return {
+    createTime: formatDuration(finishCreateTime - startCreateTime),
+    errorCount: createdUsers.map((user): number => user.user === null ? 1 : 0).reduce((acc, value) => acc + value),
+  };
+})

--- a/app/api/admin/loadtest/delete-users/route.ts
+++ b/app/api/admin/loadtest/delete-users/route.ts
@@ -1,0 +1,63 @@
+import { requestWithAuthAdmin } from "@/app/api/_common/endpoints";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { formatDuration } from "../_common/utils";
+
+async function deleteUser(supabase: SupabaseClient, verbose: boolean, id: string, email: string): Promise<number> {
+  var errorCount = 0;
+  const resp = await supabase.from('profiles').delete().eq('id', id);
+  if (resp.error) {
+    errorCount++;
+    console.log(resp.error);
+  }
+
+  const { error } = await supabase.auth.admin.deleteUser(id);
+  if (error) {
+    errorCount++;
+    console.log(error);
+  } else if (verbose) {
+    console.log(`Deleted user: ${email}`);
+  }
+
+  return errorCount;
+}
+
+export const GET = requestWithAuthAdmin(async (supabase, _profile, request, _body) => {
+  const verbose = request.nextUrl.searchParams.get("verbose") == "true" || false;
+  const parallel = request.nextUrl.searchParams.get("parallel") == "true" || false;
+
+  const { data, error } = await supabase.from('profiles').select('id,email').like('email', '%@load.test');
+  if (error) {
+    console.log(error);
+  }
+  if (data) {
+    console.log(`Found ${data.length} users to delete`);
+
+    const reducer = async (acc: Promise<number>, task: Promise<number>): Promise<number> => {
+      try {
+        const taskResult = await task;
+        return taskResult + await acc;
+      } catch (error) {
+        console.log(error);
+        return await acc;
+      };
+    }
+
+    const startDeleteTime = performance.now();
+    var errorCount = 0;
+    if (parallel) {
+      errorCount = await data.
+        map((user) => deleteUser(supabase, verbose, user.id, user.email)).
+        reduce(reducer, Promise.resolve(0));
+    } else {
+      for (let user of data) {
+        errorCount += await deleteUser(supabase, verbose, user.id, user.email);
+      }
+    }
+    const finishDeleteTime = performance.now();
+
+    return {
+      deleteTime: formatDuration(finishDeleteTime - startDeleteTime),
+      errorCount: errorCount,
+    };
+  }
+});

--- a/app/api/admin/loadtest/get-profiles/route.ts
+++ b/app/api/admin/loadtest/get-profiles/route.ts
@@ -1,0 +1,90 @@
+import { requestWithAuthAdmin } from "@/app/api/_common/endpoints";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { formatDuration } from "../_common/utils";
+import { getProfile } from "@/app/api/_common/profile";
+
+type UserStats = {
+  samples: number[],
+};
+
+async function getProfileForUser(supabase: SupabaseClient, verbose: boolean, id: string, rampupSeconds: number, runUntil: number, sleepSeconds: number): Promise<UserStats> {
+  const sleepMillis = sleepSeconds / 1000;
+  var samples: number[] = [];
+
+  // Wait for a random initial delay
+  const initialIdleSeconds = Math.random() * rampupSeconds;
+  await new Promise(resolve => setTimeout(resolve, initialIdleSeconds));
+
+  while (performance.now() < runUntil) {
+    const startTime = performance.now();
+    const profile = await getProfile(supabase, id);
+    const durationMs = performance.now() - startTime;
+    if (verbose) {
+      console.log(`${profile.email}: ${formatDuration(durationMs)}`);
+    }
+    samples.push(durationMs);
+    await new Promise(resolve => setTimeout(resolve, sleepMillis));
+  }
+
+  return {
+    samples: samples,
+  };
+}
+
+export const GET = requestWithAuthAdmin(async (supabase, _profile, request, _body) => {
+  const runDuration = parseFloat(request.nextUrl.searchParams.get("run_duration") ?? "5.0");
+  const sleepDuration = parseFloat(request.nextUrl.searchParams.get("sleep_duration") ?? "1.0");
+  const rampupDuration = parseFloat(request.nextUrl.searchParams.get("rampup_duration") ?? "2.0");
+  const numUsers = parseInt(request.nextUrl.searchParams.get("num_users") ?? "0");
+  const verbose = request.nextUrl.searchParams.get("verbose") == "true" || false;
+
+  const { data, error } = await supabase.from('profiles').select('id,email').like('email', '%@load.test');
+  if (error) {
+    console.log(error);
+  }
+  if (data) {
+    console.log(`Found ${data.length} load test users`);
+
+    var users = data;
+    if (numUsers != 0) {
+      console.log(`Limiting to ${numUsers} load test users`);
+      users = data.slice(0, numUsers);
+    }
+
+    const reducer = async (accPromise: Promise<UserStats>, userStatsPromise: Promise<UserStats>): Promise<UserStats> => {
+      try {
+        const userStats = await userStatsPromise;
+        return await accPromise.then((acc) => {
+          acc.samples.push(...userStats.samples);
+          return acc;
+        });
+      } catch (error) {
+        console.log(error);
+        return await accPromise;
+      };
+    }
+
+    const startTime = performance.now();
+    const runUntil = startTime + (rampupDuration + runDuration) * 1000;
+    const allSamples = await users.map((user) => getProfileForUser(supabase, verbose, user.id, rampupDuration, runUntil, sleepDuration)).reduce(reducer, Promise.resolve({ samples: [] }));
+
+    var min = Number.MAX_VALUE;
+    var max = 0;
+    var sum = 0;
+    for (let sample of allSamples.samples) {
+      sum += sample;
+      if (sample < min) {
+        min = sample;
+      }
+      if (sample > max) {
+        max = sample;
+      }
+    }
+
+    return {
+      min: formatDuration(min),
+      max: formatDuration(max),
+      avg: formatDuration(sum / allSamples.samples.length),
+    }
+  }
+})


### PR DESCRIPTION
I've only played around with this locally. Lots of stuff to improve/add, like adding more info to other tables for the users like lottery tickets and memberships.

### Usage

log in as an admin and visit:
* create users: <http://localhost:3000/api/admin/loadtest/create-users?verbose=false&num_users=100>
* make 20 load test users continuously call `getProfile()` in parallel for 5 seconds with 1s sleep between each call, 2s rampup: <http://localhost:3000/api/admin/loadtest/get-profiles?verbose=false&run_duration=5&rampup_duration=2&sleep_duration=1&num_users=20>
* delete all load test users: http://localhost:3000/api/admin/loadtest/delete-users?verbose=true

There's also a `parallel=<bool>` flag for create/delete which will try to do it async, but it seems to cause issues if you want a lot of users so it's off by default