### PR TITLE
Fix transfer refunds silently failing and leaving members unpaid

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -8,7 +8,12 @@ import {
 } from "@/utils/types";
 import { query } from "@/app/api/_common/endpoints";
 import { stripeCurrenciesWithoutDecimals } from "@/app/api/_common/stripe";
-import { transferRefundAmount } from "@/utils/stripe/transfers";
+import {
+  buildRefundFailureEmail,
+  REFUND_FAILURE_ALERT_EMAIL,
+  transferRefundAmount,
+} from "@/utils/stripe/transfers";
+import { sendEmail } from "@/app/_components/email";
 
 export async function POST(req: Request) {
   const supabase = await createClient();
@@ -191,6 +196,7 @@ export async function POST(req: Request) {
         // rejected it, and the member went unpaid until someone noticed by hand.
         let refundedMinorUnits = 0;
         let refundError: string | null = null;
+        let intendedMinorUnits: number | null = null;
 
         if (revokedMembership.stripe_payment_intent_id) {
           try {
@@ -206,6 +212,7 @@ export async function POST(req: Request) {
               charge.amount - charge.amount_refunded,
               burnConfig.transfer_fee_percentage ?? 0,
             );
+            intendedMinorUnits = amount;
             if (amount > 0) {
               const refund = await stripe.refunds.create({
                 payment_intent: revokedMembership.stripe_payment_intent_id,
@@ -241,6 +248,43 @@ export async function POST(req: Request) {
               : null,
           }),
         );
+
+        // Someone is now owed money and only a human can fix it, so tell them.
+        // Wrapped because a mail outage must not take the transfer down with it -
+        // the row above is already the durable record.
+        if (refundError) {
+          try {
+            const owner = await query(() =>
+              supabase
+                .from("profiles")
+                .select("email")
+                .eq("id", revokedMembership.owner_id)
+                .maybeSingle(),
+            );
+            const { subject, text } = buildRefundFailureEmail({
+              projectName: suitableProjects[0].name,
+              memberName:
+                `${revokedMembership.first_name ?? ""} ${revokedMembership.last_name ?? ""}`.trim() ||
+                "unknown",
+              memberEmail: owner?.email ?? null,
+              membershipId: revokedMembership.id,
+              paymentIntentId: revokedMembership.stripe_payment_intent_id ?? null,
+              intendedAmount:
+                intendedMinorUnits === null
+                  ? null
+                  : intendedMinorUnits / minorUnitFactor,
+              currency: revokedMembership.price_currency,
+              error: refundError,
+            });
+            await sendEmail(REFUND_FAILURE_ALERT_EMAIL, subject, text);
+          } catch (e) {
+            console.error(
+              "[ERROR] could not send the refund-failure alert; the failure is " +
+                "still recorded on the burn_membership_transfers row",
+              e,
+            );
+          }
+        }
 
         // Delete the original membership since it's been transferred
         await query(() =>

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/utils/types";
 import { query } from "@/app/api/_common/endpoints";
 import { stripeCurrenciesWithoutDecimals } from "@/app/api/_common/stripe";
+import { transferRefundAmount } from "@/utils/stripe/transfers";
 
 export async function POST(req: Request) {
   const supabase = await createClient();
@@ -174,39 +175,70 @@ export async function POST(req: Request) {
       if (membershipsBeingTransferred.length > 0) {
         const revokedMembership: BurnMembership =
           membershipsBeingTransferred[0];
-        // refund the current membership via Stripe, minus the transfer fee
+
+        const minorUnitFactor = stripeCurrenciesWithoutDecimals.includes(
+          revokedMembership.price_currency.toUpperCase(),
+        )
+          ? 1
+          : 100;
+
+        // Refund the current membership via Stripe, minus the transfer fee.
+        //
+        // The amount is based on what Stripe still considers refundable, not on
+        // burn_memberships.price. That column is not reduced by refunds issued
+        // outside this flow, so after a manual addon refund it overstated what the
+        // member held; the resulting refund exceeded the refundable balance, Stripe
+        // rejected it, and the member went unpaid until someone noticed by hand.
+        let refundedMinorUnits = 0;
+        let refundError: string | null = null;
+
         if (revokedMembership.stripe_payment_intent_id) {
           try {
-            await stripe.refunds.create({
-              payment_intent: revokedMembership.stripe_payment_intent_id,
-              amount: Math.round(
-                revokedMembership.price *
-                (1 - (burnConfig.transfer_fee_percentage ?? 0) / 100) *
-                (stripeCurrenciesWithoutDecimals.includes(
-                  revokedMembership.price_currency.toUpperCase(),
-                )
-                  ? 1
-                  : 100),
-              ),
-            });
-          } catch (e) {
-            console.error("[WARNING] refund could not be created, see the following stack trace for details")
-            console.error(e);
+            const paymentIntent = await stripe.paymentIntents.retrieve(
+              revokedMembership.stripe_payment_intent_id,
+              { expand: ["latest_charge"] },
+            );
+            const charge = paymentIntent.latest_charge as Stripe.Charge | null;
+            if (!charge) {
+              throw new Error("payment intent has no charge to refund");
+            }
+            const amount = transferRefundAmount(
+              charge.amount - charge.amount_refunded,
+              burnConfig.transfer_fee_percentage ?? 0,
+            );
+            if (amount > 0) {
+              const refund = await stripe.refunds.create({
+                payment_intent: revokedMembership.stripe_payment_intent_id,
+                amount,
+              });
+              // Record what Stripe actually did, not what we asked for.
+              refundedMinorUnits = refund.amount;
+            }
+          } catch (e: any) {
+            refundError = e?.message ?? String(e);
+            console.error(
+              `[ERROR] transfer refund failed for membership ${revokedMembership.id} ` +
+                `(payment intent ${revokedMembership.stripe_payment_intent_id}); ` +
+                `the transfer will still complete and this member is owed money`,
+              e,
+            );
           }
         }
 
-        // Log the transfer before deleting the membership
-        const refundAmount =
-          revokedMembership.price *
-          (1 - (burnConfig.transfer_fee_percentage ?? 0) / 100);
+        // Log the transfer before deleting the membership. A failed refund is
+        // recorded on the row rather than left to a log line, so the people owed
+        // money can be found with a query.
         await query(() =>
           supabase.from("burn_membership_transfers").insert({
             project_id: projectId,
             from_owner_id: revokedMembership.owner_id,
             to_owner_id: membershipPurchaseRight.owner_id,
-            refund_amount: refundAmount,
+            refund_amount: refundedMinorUnits / minorUnitFactor,
             price_currency: revokedMembership.price_currency,
             original_membership_json: revokedMembership,
+            metadata: refundError
+              ? { refund_failed: true, refund_error: refundError }
+              : null,
           }),
         );
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prettier-fix": "prettier --write .",
     "stripe:login": "stripe login",
     "stripe:listen": "stripe listen --forward-to=localhost:3000/api/webhooks/stripe",

--- a/supabase/migrations/20260728140000_burn_membership_transfers_metadata.sql
+++ b/supabase/migrations/20260728140000_burn_membership_transfers_metadata.sql
@@ -1,0 +1,6 @@
+-- Lets a failed transfer refund be recorded on the row itself, so members who are
+-- owed money can be found with a query rather than by reading server logs.
+--
+-- IF NOT EXISTS because the statistics work adds the same column for its backfill
+-- marker; whichever migration lands first wins and the other is a no-op.
+alter table burn_membership_transfers add column if not exists metadata jsonb;

--- a/utils/stripe/transfers.test.ts
+++ b/utils/stripe/transfers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { transferRefundAmount } from "@/utils/stripe/transfers";
+
+describe("transferRefundAmount", () => {
+  it("keeps the transfer fee on a normal membership", () => {
+    // 2222 SEK, 3% fee
+    expect(transferRefundAmount(222_200, 3)).toBe(215_534);
+    // 2222 SEK, 50% fee
+    expect(transferRefundAmount(222_200, 50)).toBe(111_100);
+  });
+
+  it("bases the refund on what is still refundable, not the original price", () => {
+    // The real failure: paid 2822, 600 of it already refunded as an Alversjö
+    // cancellation, so only 2222 remains. The old code computed 2822 * 0.97 =
+    // 2737.34, which exceeds the refundable balance and Stripe rejects.
+    expect(transferRefundAmount(222_200, 3)).toBe(215_534);
+    expect(transferRefundAmount(282_200, 3)).toBe(273_734);
+  });
+
+  it("never exceeds what is still refundable", () => {
+    for (const fee of [0, 3, 50, 100]) {
+      expect(transferRefundAmount(222_200, fee)).toBeLessThanOrEqual(222_200);
+    }
+  });
+
+  it("returns nothing when the payment is already fully refunded", () => {
+    expect(transferRefundAmount(0, 3)).toBe(0);
+    expect(transferRefundAmount(-100, 3)).toBe(0);
+  });
+
+  it("refunds everything at a zero fee and nothing at a hundred percent", () => {
+    expect(transferRefundAmount(222_200, 0)).toBe(222_200);
+    expect(transferRefundAmount(222_200, 100)).toBe(0);
+  });
+
+  it("clamps a nonsensical fee rather than paying out more than was held", () => {
+    expect(transferRefundAmount(222_200, -10)).toBe(222_200);
+    expect(transferRefundAmount(222_200, 150)).toBe(0);
+  });
+
+  it("rounds to whole minor units", () => {
+    expect(Number.isInteger(transferRefundAmount(123_401, 3))).toBe(true);
+  });
+});

--- a/utils/stripe/transfers.test.ts
+++ b/utils/stripe/transfers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { transferRefundAmount } from "@/utils/stripe/transfers";
+import {
+  buildRefundFailureEmail,
+  REFUND_FAILURE_ALERT_EMAIL,
+  transferRefundAmount,
+} from "@/utils/stripe/transfers";
 
 describe("transferRefundAmount", () => {
   it("keeps the transfer fee on a normal membership", () => {
@@ -40,5 +44,54 @@ describe("transferRefundAmount", () => {
 
   it("rounds to whole minor units", () => {
     expect(Number.isInteger(transferRefundAmount(123_401, 3))).toBe(true);
+  });
+});
+
+describe("buildRefundFailureEmail", () => {
+  const base = {
+    projectName: "The Borderland 2026",
+    memberName: "Ida Björses",
+    memberEmail: "ida@example.com",
+    membershipId: "e2c9f1ce-de6f-406a-819a-afef7351aadb",
+    paymentIntentId: "pi_3T9THOEuBjGnolU21apcAVYQ",
+    intendedAmount: 2155.34,
+    currency: "SEK",
+    error: "Refund amount exceeds the remaining charge amount.",
+  };
+
+  it("names the burn and the member in the subject", () => {
+    const { subject } = buildRefundFailureEmail(base);
+    expect(subject).toContain("The Borderland 2026");
+    expect(subject).toContain("Ida Björses");
+    expect(subject).toContain("FAILED");
+  });
+
+  it("carries everything needed to refund by hand", () => {
+    const { text } = buildRefundFailureEmail(base);
+    expect(text).toContain("ida@example.com");
+    expect(text).toContain("2155.34 SEK");
+    expect(text).toContain("pi_3T9THOEuBjGnolU21apcAVYQ");
+    expect(text).toContain(base.membershipId);
+    expect(text).toContain("Refund amount exceeds the remaining charge amount.");
+  });
+
+  it("says plainly that the member has lost their membership and not been paid", () => {
+    const { text } = buildRefundFailureEmail(base);
+    expect(text).toContain("NOT been paid");
+  });
+
+  it("copes with a member whose email or amount is unknown", () => {
+    const { text } = buildRefundFailureEmail({
+      ...base,
+      memberEmail: null,
+      intendedAmount: null,
+      paymentIntentId: null,
+    });
+    expect(text).toContain("unknown");
+    expect(text).toContain("none recorded");
+  });
+
+  it("alerts tech@theborderland.se", () => {
+    expect(REFUND_FAILURE_ALERT_EMAIL).toBe("tech@theborderland.se");
   });
 });

--- a/utils/stripe/transfers.ts
+++ b/utils/stripe/transfers.ts
@@ -18,3 +18,51 @@ export function transferRefundAmount(
   const fee = Math.min(Math.max(transferFeePercentage, 0), 100);
   return Math.round(stillRefundable * (1 - fee / 100));
 }
+
+/** Where failed-refund alerts go. */
+export const REFUND_FAILURE_ALERT_EMAIL = "tech@theborderland.se";
+
+/**
+ * The alert sent when a transfer refund fails. Someone is owed money and only a
+ * human can put it right, so the message leads with that and carries everything
+ * needed to issue the refund by hand.
+ */
+export function buildRefundFailureEmail(input: {
+  projectName: string;
+  memberName: string;
+  memberEmail: string | null;
+  membershipId: string;
+  paymentIntentId: string | null;
+  intendedAmount: number | null;
+  currency: string;
+  error: string;
+}): { subject: string; text: string } {
+  const amount =
+    input.intendedAmount === null
+      ? "unknown"
+      : `${input.intendedAmount.toFixed(2)} ${input.currency}`;
+
+  return {
+    subject: `[${input.projectName}] Transfer refund FAILED — ${input.memberName} is owed money`,
+    text: [
+      `A membership transfer completed, but refunding the member who gave up their`,
+      `membership failed. The transfer went through regardless, so this person has`,
+      `lost their membership and has NOT been paid. This needs a manual refund.`,
+      ``,
+      `Member:          ${input.memberName}`,
+      `Email:           ${input.memberEmail ?? "unknown"}`,
+      `Amount owed:     ${amount}`,
+      `Payment intent:  ${input.paymentIntentId ?? "none recorded"}`,
+      `Membership id:   ${input.membershipId}`,
+      ``,
+      `Stripe error:    ${input.error}`,
+      ``,
+      `To refund by hand, open the payment intent in the Stripe dashboard and`,
+      `refund the amount above. Then correct refund_amount on the matching row in`,
+      `burn_membership_transfers and clear its metadata.refund_failed flag.`,
+      ``,
+      `Outstanding cases can be listed with:`,
+      `  select * from burn_membership_transfers where metadata->>'refund_failed' = 'true';`,
+    ].join("\n"),
+  };
+}

--- a/utils/stripe/transfers.ts
+++ b/utils/stripe/transfers.ts
@@ -1,0 +1,20 @@
+/**
+ * How much to refund the member giving up their membership in a transfer.
+ *
+ * The basis is what Stripe says is *still refundable* on the original payment,
+ * not burn_memberships.price. That column is not reduced by refunds made outside
+ * the transfer flow — a manual dashboard refund of an Alversjö addon, say — so it
+ * can claim a member paid more than they still hold. When it did, the resulting
+ * refund exceeded the refundable balance, Stripe rejected it, and the member was
+ * left unpaid for weeks.
+ *
+ * Both arguments and the result are in Stripe minor units.
+ */
+export function transferRefundAmount(
+  stillRefundable: number,
+  transferFeePercentage: number,
+): number {
+  if (stillRefundable <= 0) return 0;
+  const fee = Math.min(Math.max(transferFeePercentage, 0), 100);
+  return Math.round(stillRefundable * (1 - fee / 100));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["utils/**/*.test.ts", "app/**/*.test.ts"],
+  },
+  resolve: {
+    alias: { "@": path.resolve(__dirname, ".") },
+  },
+});


### PR DESCRIPTION
Three members gave up their memberships in a transfer and **received nothing for 10.9, 20.1 and 24.7 days**, until someone refunded them by hand. One of them had to chase us for it. This fixes the cause and makes the failure impossible to miss next time.

## What happened

`burn_memberships.price` is never reduced by a refund issued outside the transfer flow. On 2026-03-15 six Alversjö addons were refunded 600 SEK each directly in the Stripe dashboard, but those membership rows still read **2822** instead of 2222.

When those six later transferred, the refund was computed from the stale price:

```
2822 × 0.97 = 2737.34,  against only 2222 still refundable
```

Stripe rejects a refund larger than the refundable balance. The `catch` turned that into a logged warning and execution continued, so the transfer **completed anyway** — old membership deleted, transfer row written claiming a 2737.34 refund that never happened, new member handed their membership — while the outgoing member got nothing.

It looked like a clean transfer from every angle except their bank account.

The same stale price also over-refunded the three who transferred during the 50% era: they received 1411 where the policy figure was 1111, **300 SEK each**.

## The fix

**Refund basis.** Computed from `charge.amount − charge.amount_refunded`, read live from Stripe, instead of from `burn_memberships.price`. For the affected six that gives `2222 × 0.97 = 2155.34` — exactly the figure the manual correction paid, which is good evidence it's the intended amount.

Extracted as `transferRefundAmount()` in `utils/stripe/transfers.ts` so it's unit tested, including a clamp so a misconfigured `transfer_fee_percentage` can never refund more than was held.

**Failures stop being silent.** `refund_amount` now records what Stripe actually refunded rather than what we intended, and a failure is written to the row as `metadata.refund_failed` with the error. Anyone owed money can be found with a query:

```sql
select * from burn_membership_transfers where metadata->>'refund_failed' = 'true';
```

**And an alert is sent to tech@theborderland.se**, because a row is only findable if someone thinks to look. It carries the member's name and email, the amount owed, the payment intent and the Stripe error, so the refund can be issued by hand straight from the message. Sending is wrapped in its own try/catch — an SMTP outage must not take the transfer down, and the row is already the durable record. The message is built by `buildRefundFailureEmail()` so its content is unit tested rather than only exercised once something has already gone wrong.

The transfer still completes on failure — throwing here would leave the incoming buyer paid with no membership and an already-expired purchase right, which is worse. The point is that it's now recorded rather than lost.

## Not changed

The behaviour when a member holds their full original payment is identical — `2222 × 0.97 = 2155.34` either way. This only diverges when part of the payment was already refunded, which is precisely the broken case.

## Already cleaned up separately

Against production, at the maintainer's request:

- `burn_memberships.price` corrected on three live memberships still carrying the stale 2822 → 2222. They were primed to hit this same bug on any future transfer.
- `burn_membership_transfers.refund_amount` corrected on the three rows claiming 2737.34 → 2155.34, with the old value kept in `metadata.refund_amount_corrected_from`.
- A membership that had been refunded in full outside the app, and so should have been removed, was deleted.

**Nobody is currently owed money** — all 814 transfers were checked, and none refunded less than 50% of what the member still held.

## Migration

`add column if not exists metadata jsonb` on `burn_membership_transfers`. #40 adds the same column for its backfill marker; whichever lands first wins and the other is a no-op, so the two are independent. The column already exists in production, so this migration is a no-op there.

## Checks

12 unit tests · `tsc --noEmit` clean · `npm run build` compiles · no new lint issues.

`vitest.config.ts` and the `test` scripts are included so this PR stands alone; #40 adds identical files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
