### PR TITLE
Make promoting main to production safe and legible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ For next year my dream is to have something like self-hosted Vercel, but instead
 
 ## Operations
 
+### Releasing
+
+`production` is the branch Vercel serves live; merging into `main` only builds a
+preview. Promote with `npm run release:status` then `npm run release:promote`.
+See [docs/RELEASING.md](docs/RELEASING.md) — in particular why `git log` is not a
+reliable guide to what is unreleased in this repo.
+
 To investigate Stripe webhook delivery failures (e.g. after seeing failed events in the Stripe Dashboard), run `npm run webhook:investigate` (optionally with `-- 14` for the last 14 days). This fetches both Stripe’s failed deliveries and Vercel runtime logs into `misc/`.
 
 ## Supabase

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,69 @@
+# Releasing
+
+`production` is the branch Vercel serves at members.theborderland.se. `main` is
+integration. Merging into `main` deploys a preview and nothing more.
+
+```
+feature branch  ->  PR  ->  main  ->  production (live)
+```
+
+## Promoting
+
+```bash
+npm run release:status    # what would ship, and whether the branches are sane
+npm run release:promote   # fast-forward production to main
+```
+
+`release:status` is worth reading before promoting. It lists the files that would
+change and **the authors of the work being shipped** — promoting `main` ships
+everything sitting on it, not only your own commits.
+
+## The one rule
+
+**`production` must always be an ancestor of `main`.**
+
+Hold it and every promotion is a fast-forward: it cannot conflict, and it cannot
+resurrect old code. Break it and the next promotion becomes a real merge that can
+carry surprises in both directions.
+
+The way it gets broken is committing or hotfixing straight to `production`. If
+that happens, `release:promote` refuses and tells you to restore the invariant:
+
+```bash
+git checkout main && git merge origin/production && git push origin main
+```
+
+Then promote as usual. Better still, put the hotfix on `main` and promote it —
+that keeps the history linear and the two branches honest.
+
+## `git log` lies about what is unreleased
+
+This repo has years of `Merge branch 'production'` commits from hotfixes being
+merged back, and some work has reached `production` by cherry-pick rather than by
+merge. As a result commit ancestry and file contents disagree:
+
+```bash
+git log --oneline production..main   # claimed 126 commits unreleased
+git diff --stat production main      # actually 8 files differed
+```
+
+Both numbers were "right"; only the second was useful. **Always check the diff.**
+`release:status` uses the diff for exactly this reason.
+
+This is not academic. In July 2026 a promotion was nearly made that would have
+shipped an unrelated colleague's unreleased work — a breaking change to
+`/api/auth/rea-token` among it — because the commit range was read as the source
+of truth. The work was split onto its own branch instead.
+
+## Database migrations
+
+Migrations are applied with `supabase db push` against the linked project and are
+**not** tied to a deployment. Apply them before promoting the code that needs
+them, so production never runs against a schema it does not have.
+
+If `db push` reports *"Remote migration versions not found in local migrations
+directory"*, you are on a branch missing migrations that are already applied. It
+will suggest `migration repair --status reverted`. **Do not run that** — it marks
+live migrations as reverted and invites them to be applied a second time. Check
+out a branch that has them, or place the missing files in the working tree
+uncommitted, and push again.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "release:status": "bash scripts/release.sh status",
+    "release:promote": "bash scripts/release.sh promote",
     "test:watch": "vitest",
     "prettier-fix": "prettier --write .",
     "stripe:login": "stripe login",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Promotes main to production, or reports why it cannot.
+#
+#   npm run release:status    what would ship, and whether the branches are sane
+#   npm run release:promote   fast-forward production to main
+#
+# The invariant this protects: production is always an ancestor of main. Hold it
+# and every promotion is a fast-forward that cannot conflict and cannot ship
+# anything unreviewed. Break it - by committing straight to production - and the
+# next promotion becomes a real merge that can carry surprises in either
+# direction.
+
+set -euo pipefail
+
+REMOTE="${RELEASE_REMOTE:-origin}"
+MAIN="${RELEASE_MAIN:-main}"
+PROD="${RELEASE_PROD:-production}"
+
+bold() { printf '\033[1m%s\033[0m\n' "$1"; }
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$1"; }
+
+git fetch --quiet "$REMOTE" "$MAIN" "$PROD"
+
+MAIN_REF="$REMOTE/$MAIN"
+PROD_REF="$REMOTE/$PROD"
+
+# Commits on production that main has never seen. Almost always means somebody
+# committed or hotfixed straight to production.
+STRANDED=$(git log --oneline "$MAIN_REF..$PROD_REF" | wc -l | tr -d ' ')
+# What promoting would actually ship. Use the diff, never the commit list: this
+# repo's history has production merged back into main many times, so commit
+# ranges routinely claim work is unreleased when its content already shipped.
+CHANGED=$(git diff --name-only "$PROD_REF" "$MAIN_REF" | wc -l | tr -d ' ')
+
+bold "release status"
+echo "  $MAIN        $(git log -1 --format='%h %s' "$MAIN_REF")"
+echo "  $PROD  $(git log -1 --format='%h %s' "$PROD_REF")"
+echo
+
+if [ "$STRANDED" -ne 0 ]; then
+  red "  production has $STRANDED commit(s) that main does not:"
+  git log --format='    %h %an: %s' "$MAIN_REF..$PROD_REF" | head -20
+  echo
+  yellow "  Fix by merging production back into main first:"
+  echo "    git checkout $MAIN && git merge $PROD_REF && git push $REMOTE $MAIN"
+  echo
+fi
+
+if [ "$CHANGED" -eq 0 ]; then
+  green "  nothing to promote - production already matches main"
+else
+  bold "  $CHANGED file(s) would change:"
+  git diff --stat "$PROD_REF" "$MAIN_REF" | tail -20
+  echo
+  bold "  authors of the work being promoted:"
+  git log --format='%an' "$PROD_REF..$MAIN_REF" --no-merges | sort | uniq -c | sed 's/^/    /'
+  echo
+  yellow "  Check you mean to ship everyone listed above, not just your own work."
+fi
+
+if [ "${1:-status}" != "promote" ]; then
+  exit 0
+fi
+
+echo
+if [ "$CHANGED" -eq 0 ]; then
+  green "Nothing to do."
+  exit 0
+fi
+
+if [ "$STRANDED" -ne 0 ]; then
+  red "Refusing to promote: production would lose history, or the merge would not"
+  red "be a fast-forward. Merge production into main first (command above)."
+  exit 1
+fi
+
+bold "Promoting $MAIN -> $PROD (fast-forward)..."
+git push "$REMOTE" "$MAIN_REF:refs/heads/$PROD"
+green "Done. Vercel is deploying production; watch it with:"
+echo "  vercel list --prod"


### PR DESCRIPTION
Promoting to production is a manual merge into a branch few people think about, and this repo makes it easy to get wrong. This adds a guard, and writes down why the guard exists.

## The problem it solves

Years of `Merge branch 'production'` hotfix back-merges mean **commit ancestry and file contents disagree**:

```bash
git log --oneline production..main   # claimed 126 commits unreleased
git diff --stat production main      # actually 8 files differed
```

Both numbers were correct; only the second was useful. Reading the commit range as the source of truth nearly shipped an unrelated colleague's unreleased work — including a breaking change to `/api/auth/rea-token`, where a required `service` parameter was added — as a side effect of releasing the Stripe statistics work. That work is now split onto its own branch (#43).

## What's here

```bash
npm run release:status    # what would ship, and whether the branches are sane
npm run release:promote   # fast-forward production to main
```

`release:status` reports the files that would change **and the authors of the work being shipped**, computed from the diff rather than the commit range. That author list is the part that would have caught the near-miss above.

`release:promote` refuses when `production` holds commits `main` has never seen, and prints the merge that fixes it.

## The invariant

**`production` must always be an ancestor of `main`.** Hold it and every promotion is a fast-forward: it cannot conflict and cannot resurrect old code. The way it breaks is committing straight to `production`, which is exactly what the guard detects.

`main` and `production` are currently at the same commit, so the invariant holds today.

## Verified, not assumed

Both paths were exercised against throwaway branches pushed and then deleted:

- **production behind main** → lists 8 changed files and the authors, exits 0.
- **stranded commit on production** → prints the offending commit, refuses to promote, exits 1.

## docs/RELEASING.md

Records the branch flow, the invariant and how to restore it, the `git log` trap with the real numbers, and one more trap worth writing down: when `supabase db push` reports *"Remote migration versions not found in local migrations directory"* it suggests `migration repair --status reverted`. **Running that marks live migrations as reverted** and invites them to be applied a second time. The fix is to check out a branch that has them, or place the missing files in the working tree uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
