### PR TITLE
Statistics: admin access without a membership, and per-sale membership counts

### DIFF
--- a/app/api/_common/endpoints.ts
+++ b/app/api/_common/endpoints.ts
@@ -252,9 +252,17 @@ export function requestWithProject<T = any>(
   }, schema);
 }
 
+/**
+ * Requires a membership in the burn.
+ *
+ * `alsoAllowRoles` lets holders of those burn roles through without one. Needed
+ * because organisers do not necessarily buy memberships, and some member-facing
+ * pages are things they have to be able to see.
+ */
 export function requestWithMembership<T = any>(
   handler: RequestWithAuthHandler<T>,
   schema?: s.Object,
+  alsoAllowRoles?: BurnRole | BurnRole[],
 ) {
   return requestWithAuth(async (supabase, profile, req, body) => {
     const projectSlug = req.nextUrl.pathname.split("/")[3];
@@ -262,7 +270,9 @@ export function requestWithMembership<T = any>(
     if (!project) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
     }
-    if (!project.membership) {
+    const allowedByRole =
+      !!alsoAllowRoles && roleMatches(project.roles, alsoAllowRoles);
+    if (!project.membership && !allowedByRole) {
       return NextResponse.json(
         { error: "Membership required" },
         { status: 403 },

--- a/app/api/burn/[slug]/statistics/finances/route.ts
+++ b/app/api/burn/[slug]/statistics/finances/route.ts
@@ -7,6 +7,7 @@ import {
   TransferInput,
 } from "@/utils/stripe/types";
 import { stripeCurrenciesWithoutDecimals } from "@/app/api/_common/stripe";
+import { BurnRole } from "@/utils/types";
 
 export const GET = requestWithMembership(
   async (supabase, profile, request, body, project) => {
@@ -49,6 +50,7 @@ export const GET = requestWithMembership(
         eventEndDate: new Date(burnConfig.event_end_date ?? Date.now()),
         currency,
         transfers: [],
+        memberships: [],
         balanceSummary: emptyBalance,
         lastSyncedAt: null,
       });
@@ -109,6 +111,15 @@ export const GET = requestWithMembership(
       at: t.created_at,
     }));
 
+    // Memberships currently held, with their check-in state, so the table can
+    // show how many people each sale actually put on site.
+    const memberships = await query(() =>
+      supabase
+        .from("burn_memberships")
+        .select("stripe_payment_intent_id, checked_in_at")
+        .eq("project_id", project!.id),
+    );
+
     return aggregateFinances({
       rows,
       projectId: project!.id,
@@ -116,8 +127,15 @@ export const GET = requestWithMembership(
       eventEndDate: new Date(burnConfig.event_end_date ?? Date.now()),
       currency,
       transfers: transferInputs,
+      memberships: memberships.map((m: any) => ({
+        paymentIntentId: m.stripe_payment_intent_id ?? null,
+        checkedIn: !!m.checked_in_at,
+      })),
       balanceSummary,
       lastSyncedAt: lastRun.finished_at,
     });
   },
+  undefined,
+  // Organisers do not necessarily hold a membership, but do need the numbers.
+  BurnRole.Admin,
 );

--- a/app/api/burn/[slug]/statistics/route.ts
+++ b/app/api/burn/[slug]/statistics/route.ts
@@ -1,4 +1,5 @@
 import { requestWithMembership, query } from "@/app/api/_common/endpoints";
+import { BurnRole } from "@/utils/types";
 
 export const GET = requestWithMembership(
   async (supabase, profile, request, body, project) => {
@@ -54,6 +55,9 @@ export const GET = requestWithMembership(
       alversjo,
       total: memberships.length,
     };
-  }
+  },
+  undefined,
+  // Organisers do not necessarily hold a membership, but do need the numbers.
+  BurnRole.Admin,
 );
 

--- a/app/burn/[slug]/layout.tsx
+++ b/app/burn/[slug]/layout.tsx
@@ -110,7 +110,8 @@ export default function ProjectLayout({
             path: `/burn/${project?.slug}/newsletter`,
             icon: <MailOutlined />,
           },
-          project.membership
+          // Organisers do not necessarily hold a membership, but do need the numbers.
+          project.membership || project.roles.includes(BurnRole.Admin)
             ? {
               label: "Statistics",
               path: `/burn/${project?.slug}/statistics`,

--- a/app/burn/[slug]/statistics/FinancesSection.tsx
+++ b/app/burn/[slug]/statistics/FinancesSection.tsx
@@ -56,6 +56,14 @@ export default function FinancesSection() {
     },
     { label: "Stripe fees", get: (t) => money(t.stripeFees) },
     { label: "Net after fees", get: (t) => money(t.netAfterFees) },
+    { label: "Memberships", get: (t) => String(t.memberships) },
+    {
+      label: "Checked in",
+      get: (t) =>
+        t.memberships > 0
+          ? `${t.checkedIn} (${Math.round((t.checkedIn / t.memberships) * 100)}%)`
+          : String(t.checkedIn),
+    },
     { label: "Payments", get: (t) => String(t.payments) },
     { label: "Refunds", get: (t) => String(t.refunds) },
     { label: "Membership transfers", get: (t) => String(t.transfers) },
@@ -174,6 +182,17 @@ export default function FinancesSection() {
               {money(r.payouts.amount)}
             </td>
           </tr>
+          {r.unclassifiedMemberships > 0 && (
+            <tr>
+              <td className="py-1 pr-4 text-gray-500">
+                Memberships with no matching payment, excluded from the counts
+                above
+              </td>
+              <td className="py-1 text-right text-gray-500">
+                {r.unclassifiedMemberships}
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
 

--- a/app/burn/[slug]/statistics/page.tsx
+++ b/app/burn/[slug]/statistics/page.tsx
@@ -7,6 +7,7 @@ import { apiGet } from "@/app/_components/api";
 import { Spinner } from "@nextui-org/react";
 import Heading from "@/app/_components/Heading";
 import FinancesSection from "./FinancesSection";
+import { BurnRole } from "@/utils/types";
 import {
   BarChart,
   Bar,
@@ -38,7 +39,12 @@ const COLORS = {
 export default function StatisticsPage() {
   const { project } = useProject();
 
-  if (project && !project.membership) {
+  // Organisers do not necessarily hold a membership, but do need the numbers.
+  if (
+    project &&
+    !project.membership &&
+    !project.roles.includes(BurnRole.Admin)
+  ) {
     redirect(`/burn/${project.slug}/membership`);
   }
 

--- a/utils/stripe/attribution.test.ts
+++ b/utils/stripe/attribution.test.ts
@@ -193,6 +193,7 @@ function aggregate(
     eventEndDate: EVENT_END,
     currency: "SEK",
     transfers: [],
+    memberships: [],
     balanceSummary: EMPTY_BALANCE,
     lastSyncedAt: "2026-07-28T10:00:00Z",
     ...over,
@@ -448,6 +449,55 @@ describe("aggregateFinances", () => {
       },
     );
     expect(p.spring.transferSurplus).toBe(0);
+  });
+
+  it("counts memberships against the sale their payment falls in", () => {
+    const p = aggregate(
+      [
+        row({ payment_intent_id: "pi_fall", paid_at: "2025-11-20T09:00:00Z" }),
+        row({ payment_intent_id: "pi_spring", paid_at: "2026-03-20T09:00:00Z" }),
+      ],
+      {
+        memberships: [
+          { paymentIntentId: "pi_fall", checkedIn: true },
+          { paymentIntentId: "pi_spring", checkedIn: false },
+        ],
+      },
+    );
+    expect(p.fall.memberships).toBe(1);
+    expect(p.fall.checkedIn).toBe(1);
+    expect(p.spring.memberships).toBe(1);
+    expect(p.spring.checkedIn).toBe(0);
+    expect(p.total.memberships).toBe(2);
+    expect(p.total.checkedIn).toBe(1);
+  });
+
+  it("dates a transferred membership by the payment that acquired it", () => {
+    // The new holder paid in spring for a membership first sold in fall. It is a
+    // spring membership: that is the payment which put this person on site, and
+    // it keeps the counts consistent with the payment rows above.
+    const p = aggregate(
+      [
+        row({ payment_intent_id: "pi_original", paid_at: "2025-11-20T09:00:00Z" }),
+        row({ payment_intent_id: "pi_acquired", paid_at: "2026-06-20T09:00:00Z" }),
+      ],
+      { memberships: [{ paymentIntentId: "pi_acquired", checkedIn: true }] },
+    );
+    expect(p.fall.memberships).toBe(0);
+    expect(p.spring.memberships).toBe(1);
+    expect(p.spring.checkedIn).toBe(1);
+  });
+
+  it("reports memberships it cannot date rather than dropping them", () => {
+    const p = aggregate([row({ payment_intent_id: "pi_known" })], {
+      memberships: [
+        { paymentIntentId: "pi_known", checkedIn: false },
+        { paymentIntentId: null, checkedIn: true },
+        { paymentIntentId: "pi_not_in_mirror", checkedIn: false },
+      ],
+    });
+    expect(p.total.memberships).toBe(1);
+    expect(p.reconciliation.unclassifiedMemberships).toBe(2);
   });
 
   it("returns zeros for an empty mirror", () => {

--- a/utils/stripe/attribution.ts
+++ b/utils/stripe/attribution.ts
@@ -1,6 +1,7 @@
 import {
   BalanceSummary,
   FinancesPayload,
+  MembershipCountInput,
   MembershipPaymentRow,
   PaymentSplit,
   SaleKey,
@@ -94,6 +95,8 @@ function emptyTotals(): SaleTotals {
     refunds: 0,
     transfers: 0,
     transferSurplus: 0,
+    memberships: 0,
+    checkedIn: 0,
   };
 }
 
@@ -107,6 +110,8 @@ function addInto(target: SaleTotals, source: SaleTotals) {
   target.refunds += source.refunds;
   target.transfers += source.transfers;
   target.transferSurplus += source.transferSurplus;
+  target.memberships += source.memberships;
+  target.checkedIn += source.checkedIn;
 }
 
 /** Total refunded on a payment. */
@@ -132,6 +137,7 @@ export function aggregateFinances(input: {
   eventEndDate: Date;
   currency: string;
   transfers: TransferInput[];
+  memberships: MembershipCountInput[];
   balanceSummary: BalanceSummary;
   lastSyncedAt: string | null;
 }): FinancesPayload {
@@ -231,6 +237,25 @@ export function aggregateFinances(input: {
       .transferSurplus += surplus;
   }
 
+  // Memberships currently held, counted against the sale they were bought in.
+  // A membership acquired by transfer is dated by the payment that acquired it,
+  // not by the original holder's purchase, which is what makes the counts add up
+  // against the payments above.
+  let unclassifiedMemberships = 0;
+  for (const membership of input.memberships) {
+    const payment = membership.paymentIntentId
+      ? byPaymentIntent.get(membership.paymentIntentId)
+      : undefined;
+    if (!payment) {
+      unclassifiedMemberships++;
+      continue;
+    }
+    const totals =
+      sales[classifySale(new Date(payment.paid_at), input.eventEndDate)];
+    totals.memberships++;
+    if (membership.checkedIn) totals.checkedIn++;
+  }
+
   const total = emptyTotals();
   addInto(total, sales.fall);
   addInto(total, sales.spring);
@@ -264,6 +289,7 @@ export function aggregateFinances(input: {
       balanceNetExcludingPayouts: input.balanceSummary.netExcludingPayouts,
       residual: input.balanceSummary.netExcludingPayouts - accountedFor,
       payouts: input.balanceSummary.payouts,
+      unclassifiedMemberships,
     },
     lastSyncedAt: input.lastSyncedAt,
   };

--- a/utils/stripe/types.ts
+++ b/utils/stripe/types.ts
@@ -56,6 +56,10 @@ export type SaleTotals = {
   payments: number;
   refunds: number;
   transfers: number;
+  /** Memberships currently held that were bought in this sale. */
+  memberships: number;
+  /** How many of those memberships were checked in at the gate. */
+  checkedIn: number;
   /**
    * What the burn gained (or lost) because these transfers happened, versus the
    * original holders simply keeping their memberships:
@@ -65,6 +69,13 @@ export type SaleTotals = {
    * 3% era made routine.
    */
   transferSurplus: number;
+};
+
+/** One currently-held membership, for counting by the sale it was bought in. */
+export type MembershipCountInput = {
+  /** Identifies the payment, and so the sale. Null for pre-Stripe memberships. */
+  paymentIntentId: string | null;
+  checkedIn: boolean;
 };
 
 /** One transfer, as the aggregator needs it to price the surplus. */
@@ -105,6 +116,8 @@ export type FinancesPayload = {
     /** balanceNetExcludingPayouts − everything accounted for above. Should be 0. */
     residual: number;
     payouts: { count: number; amount: number };
+    /** Memberships whose payment is not in the mirror, so cannot be dated. */
+    unclassifiedMemberships: number;
   };
   lastSyncedAt: string | null;
 };


### PR DESCRIPTION
Two follow-ups to #40.

## Admins can see the statistics without a membership

Access was gated purely on holding a membership: the page redirected, the sidebar hid the link, and both endpoints answered `403`. Organisers do not necessarily buy a membership — and the people who need these figures for the tax advisor are exactly those organisers.

`requestWithMembership` now takes an optional set of roles that may pass without one, and both statistics endpoints let `BurnRole.Admin` through. The page and the sidebar link follow the same rule.

Deliberately narrow: it's an explicit opt-in per endpoint, not a blanket weakening of `requestWithMembership`. Everything else that uses it is unchanged.

## Memberships and check-ins per sale

Two new rows in the finances table:

| | Fall | Spring | Total |
|---|---|---|---|
| Memberships | 2,445 | 2,993 | 5,438 |
| Checked in | 2,134 (87%) | 2,799 (94%) | 4,933 (91%) |

A membership acquired by transfer is dated by **the payment that acquired it**, not by the original holder's purchase. That's what keeps these counts consistent with the payment rows directly above them, and it means "fall memberships" reads as "memberships this sale actually put on site".

**Five memberships have no Stripe payment behind them** — all `price = 0`, comped by hand, four of them checked in. They can't be attributed to a sale, so they're reported in the reconciliation block rather than dropped or guessed at. The arithmetic closes: 2,445 + 2,993 + 5 = 5,443, the full membership count.

## Checks

58 unit tests (3 new: counting by sale, dating a transferred membership by its acquiring payment, and reporting undatable ones) · `tsc --noEmit` clean · `npm run build` compiles · no new lint warnings.

Figures above are from production data, not fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
