### PR TITLE
Query data as service_role, not as the signed-in user

### DIFF
--- a/app/api/_common/endpoints.ts
+++ b/app/api/_common/endpoints.ts
@@ -1,6 +1,6 @@
 import { s } from "ajv-ts";
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import { createAdminClient, createClient } from "@/utils/supabase/server";
 import { SupabaseClient } from "@supabase/supabase-js";
 import {
   Profile,
@@ -33,7 +33,7 @@ export function requestWithAPIKey<T = any>(
 ) {
   return async (req: NextRequest) => {
     const startTime = Date.now();
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       const response = NextResponse.json(
@@ -132,8 +132,12 @@ export function requestWithAuth<T = any>(
 ) {
   return async (req: NextRequest) => {
     const startTime = Date.now();
-    const supabase = await createClient();
-    const { data: getUserData } = await supabase.auth.getUser();
+    // The cookie-backed client is only for reading the session. Data access uses
+    // the admin client, because the cookie client sends the user's token and so
+    // runs as `authenticated`, where RLS silently yields zero rows.
+    const authClient = await createClient();
+    const { data: getUserData } = await authClient.auth.getUser();
+    const supabase = createAdminClient();
 
     const userId = getUserData?.user?.id;
     if (!userId) {

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import { createAdminClient } from "@/utils/supabase/server";
 import { query } from "@/app/api/_common/endpoints";
 import { getProjectBySlug } from "@/app/api/_common/profile";
 
@@ -49,7 +49,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const supabase = await createClient();
+  // Data access must not run as `authenticated`; see createAdminClient.
+  const supabase = createAdminClient();
 
   try {
     // Get the project

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,6 @@
 import Stripe from "stripe";
 import { NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import { createAdminClient } from "@/utils/supabase/server";
 import {
   BurnConfig,
   BurnMembership,
@@ -16,7 +16,8 @@ import {
 import { sendEmail } from "@/app/_components/email";
 
 export async function POST(req: Request) {
-  const supabase = await createClient();
+  // Data access must not run as `authenticated`; see createAdminClient.
+  const supabase = createAdminClient();
   const allProjects = await query(() =>
     supabase.from("projects").select("*, burn_config(*)"),
   );

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,5 +1,9 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { SupabaseClient, User } from "@supabase/supabase-js";
+import {
+  createClient as createSupabaseClient,
+  SupabaseClient,
+  User,
+} from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
@@ -49,6 +53,27 @@ export async function createClient() {
         },
       },
     }
+  );
+}
+
+/**
+ * A service role client with no user session attached.
+ *
+ * createClient() is built from cookies, so once a user is signed in @supabase/ssr
+ * sends their access token as the Authorization header. PostgREST then runs the
+ * query as `authenticated` rather than `service_role`, and row level security
+ * applies - which for tables with RLS enabled and no policies means every query
+ * silently returns zero rows. That is a trap: it looks like missing data, not a
+ * permissions error.
+ *
+ * Use this for data access in API routes. Authorization is enforced by the
+ * requestWith* wrappers in app/api/_common/endpoints.ts, not by RLS.
+ */
+export function createAdminClient(): SupabaseClient {
+  return createSupabaseClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
   );
 }
 


### PR DESCRIPTION
**Production is currently degraded for signed-in users. This fixes it.**

## What broke

`createClient()` is built from cookies, so once a user is signed in `@supabase/ssr` sends their access token as the `Authorization` header. PostgREST then runs the query as **`authenticated`**, not `service_role`.

On a table with RLS enabled and no policies that returns **zero rows** — with a `200` and an empty array. No error. It reads as missing data, not as a permissions problem.

So enabling RLS in #41 broke, for signed-in users only:

- the finances section — `stripe_sync_runs` came back empty, so it fell into the "never synchronized" path and showed zeros
- request logging — `Failed to log request` on every request
- `burn_timeline_events`, `burn_links`, `burn_ideas`, `burn_idea_votes`, `burn_welcome`, `burn_saved_seats`, `burn_membership_transfers`, `burn_membership_notes`, `burn_membership_checkin_events`, `burn_low_income_applications`, `questions`

Signed-**out** requests were unaffected, because with no session the client falls back to the service role key. That is exactly why this survived my testing: every check I ran used scripts or `curl` with no user session.

## The fix

`createAdminClient()` — service role, no cookies, no session. The `requestWith*` wrappers now read the session with the cookie client and pass the admin client to handlers. Authorization stays where it already was, in the wrappers; data access no longer depends on which role the caller happens to be. `metrics` and the Stripe webhook use it directly for the same reason.

This keeps the RLS lockdown from #41 intact — the anon key still cannot read those tables.

## Verified

With a user token minted via the admin API against production:

| | as `authenticated` | as `service_role` |
|---|---|---|
| `stripe_membership_payments` | 0 rows | 12,293 |
| `stripe_sync_runs` | 0 rows | 1 |
| `burn_membership_transfers` | 0 rows | 814 |
| `request_logs` | 0 rows | 596,846 |
| `burn_memberships` (no RLS) | returns data | returns data |

58 tests · `tsc --noEmit` clean · build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)