### PR TITLE
Finances: BL 2026 only, money in/out, and the Alversjö invoice

### DIFF
--- a/app/api/burn/[slug]/statistics/finances/route.ts
+++ b/app/api/burn/[slug]/statistics/finances/route.ts
@@ -2,7 +2,6 @@ import { requestWithMembership, query } from "@/app/api/_common/endpoints";
 import { aggregateFinances } from "@/utils/stripe/attribution";
 import {
   ALVERSJO_ADDON_ID,
-  BalanceSummary,
   MembershipPaymentRow,
   TransferInput,
 } from "@/utils/stripe/types";
@@ -28,19 +27,13 @@ export const GET = requestWithMembership(
     const lastRun = await query(() =>
       supabase
         .from("stripe_sync_runs")
-        .select("finished_at, stripe_account_id")
+        .select("finished_at")
         .eq("project_id", project!.id)
         .eq("status", "completed")
         .order("finished_at", { ascending: false })
         .limit(1)
         .maybeSingle(),
     );
-
-    const emptyBalance: BalanceSummary = {
-      netExcludingPayouts: 0,
-      payouts: { count: 0, amount: 0 },
-      other: { count: 0, amount: 0 },
-    };
 
     if (!lastRun) {
       return aggregateFinances({
@@ -51,7 +44,6 @@ export const GET = requestWithMembership(
         currency,
         transfers: [],
         memberships: [],
-        balanceSummary: emptyBalance,
         lastSyncedAt: null,
       });
     }
@@ -60,40 +52,6 @@ export const GET = requestWithMembership(
       supabase.from("stripe_membership_payments").select("*"),
     );
 
-    const balanceTransactions = await query(() =>
-      supabase
-        .from("stripe_balance_transactions")
-        .select("type, amount, net, reporting_category")
-        .eq("stripe_account_id", lastRun.stripe_account_id),
-    );
-
-    const balanceSummary: BalanceSummary = {
-      netExcludingPayouts: 0,
-      payouts: { count: 0, amount: 0 },
-      other: { count: 0, amount: 0 },
-    };
-    for (const bt of balanceTransactions) {
-      if (bt.type === "payout") {
-        balanceSummary.payouts.count++;
-        balanceSummary.payouts.amount += bt.amount;
-        continue;
-      }
-      // `net` (amount minus the fee Stripe took), not `amount`: the sale rows are
-      // reported net of fees, so summing gross here would leave the whole fee bill
-      // sitting in the residual.
-      balanceSummary.netExcludingPayouts += bt.net;
-      // Dispute entries stay in the balance total — the money really did leave —
-      // but must not enter `other`, because the sale rows already deduct the
-      // disputed amount and its fee. Counting them here would subtract twice.
-      if (
-        bt.type !== "charge" &&
-        bt.type !== "refund" &&
-        bt.reporting_category !== "dispute"
-      ) {
-        balanceSummary.other.count++;
-        balanceSummary.other.amount += bt.net;
-      }
-    }
 
     // Transfers are counted against the sale the *original* membership was bought
     // in, which its payment intent identifies. Requires the backfill script for the
@@ -131,7 +89,6 @@ export const GET = requestWithMembership(
         paymentIntentId: m.stripe_payment_intent_id ?? null,
         checkedIn: !!m.checked_in_at,
       })),
-      balanceSummary,
       lastSyncedAt: lastRun.finished_at,
     });
   },

--- a/app/burn/[slug]/statistics/FinancesSection.tsx
+++ b/app/burn/[slug]/statistics/FinancesSection.tsx
@@ -55,7 +55,7 @@ export default function FinancesSection() {
       strong: true,
     },
     { label: "Stripe fees", get: (t) => money(t.stripeFees) },
-    { label: "Net after fees", get: (t) => money(t.netAfterFees) },
+    { label: "Net kept", get: (t) => money(t.netKept) },
     { label: "Memberships", get: (t) => String(t.memberships) },
     {
       label: "Checked in",

--- a/app/burn/[slug]/statistics/FinancesSection.tsx
+++ b/app/burn/[slug]/statistics/FinancesSection.tsx
@@ -5,7 +5,11 @@ import { Spinner } from "@nextui-org/react";
 import { useProject } from "@/app/_components/SessionContext";
 import { apiGet } from "@/app/_components/api";
 import { formatMoney } from "@/app/_components/utils";
-import { FinancesPayload, SaleTotals } from "@/utils/stripe/types";
+import {
+  ALVERSJO_VAT_RATE,
+  FinancesPayload,
+  SaleTotals,
+} from "@/utils/stripe/types";
 import { stripeCurrenciesWithoutDecimals } from "@/app/api/_common/stripe";
 
 export default function FinancesSection() {
@@ -54,8 +58,9 @@ export default function FinancesSection() {
       get: (t) => money(t.operatingIncome),
       strong: true,
     },
-    { label: "Stripe fees", get: (t) => money(t.stripeFees) },
-    { label: "Net kept", get: (t) => money(t.netKept) },
+    { label: "Stripe fees", get: (t) => money(-t.stripeFees) },
+    { label: "Chargebacks", get: (t) => money(-t.chargebacks) },
+    { label: "Net kept", get: (t) => money(t.netKept), strong: true },
     { label: "Memberships", get: (t) => String(t.memberships) },
     {
       label: "Checked in",
@@ -77,17 +82,15 @@ export default function FinancesSection() {
     !data.lastSyncedAt ||
     Date.now() - Date.parse(data.lastSyncedAt) > 24 * 60 * 60 * 1000;
 
-  const r = data.reconciliation;
+  const inv = data.alversjoInvoice;
 
   return (
     <div className="bg-white p-4 sm:p-6 rounded-lg shadow mt-4">
       <h2 className="text-base sm:text-lg font-semibold mb-1">Finances</h2>
       <p className="text-xs sm:text-sm text-gray-500 mb-4">
-        Taken directly from Stripe. Gross and net are both shown: operating income
-        is payments less refunds, before fees. Surplus from transfers is what the
-        burn gained because memberships changed hands rather than the original
-        holders keeping them — the retained transfer fee less the Stripe fee on the
-        incoming payment, so it can be negative.
+        Taken directly from Stripe, for this burn only. Operating income is
+        payments less refunds, before fees. Chargebacks are payments reversed by
+        the cardholder&apos;s bank, including Stripe&apos;s fee for them.
       </p>
 
       <div className="overflow-x-auto">
@@ -127,74 +130,63 @@ export default function FinancesSection() {
         </table>
       </div>
 
-      <h3 className="text-sm font-semibold mt-6 mb-1">Reconciliation</h3>
+      {data.carerMemberships > 0 && (
+        <p className="text-xs text-gray-500 mt-2">
+          Of the total, {data.carerMemberships} are free carer memberships for
+          people supporting a person with a disability. They have no payment, so
+          they appear only in the total.
+        </p>
+      )}
+
+      <h3 className="text-sm font-semibold mt-6 mb-1">Alversjö invoice</h3>
       <p className="text-xs text-gray-500 mb-2">
-        Why the sale rows do not equal the bank statement.
+        What Alversjö should invoice BL for the land memberships. Covers the
+        spring memberships — the fall ones were already invoiced — and the Stripe
+        fees from both sales, since fall&apos;s were never deducted.
       </p>
-      <table className="w-full text-sm">
-        <tbody>
-          <tr className="border-b">
-            <td className="py-1 pr-4">Sale rows, net of fees</td>
-            <td className="py-1 text-right">{money(r.saleRowsNet)}</td>
-          </tr>
-          <tr className="border-b">
-            <td className="py-1 pr-4">
-              Payments not belonging to this burn ({r.unattributedPayments.count}
-              ), net
-            </td>
-            <td className="py-1 text-right">
-              {money(r.unattributedPayments.net)}
-            </td>
-          </tr>
-          <tr className="border-b">
-            <td className="py-1 pr-4">
-              Disputes ({r.disputes.count}), incl. {money(r.disputes.fees)} in fees
-            </td>
-            <td className="py-1 text-right">{money(r.disputes.amount)}</td>
-          </tr>
-          <tr className="border-b">
-            <td className="py-1 pr-4">
-              Other balance transactions ({r.otherBalanceTransactions.count})
-            </td>
-            <td className="py-1 text-right">
-              {money(r.otherBalanceTransactions.amount)}
-            </td>
-          </tr>
-          <tr className="border-b font-semibold">
-            <td className="py-1 pr-4">Stripe balance movement (excl. payouts)</td>
-            <td className="py-1 text-right">
-              {money(r.balanceNetExcludingPayouts)}
-            </td>
-          </tr>
-          <tr className="border-b">
-            <td className="py-1 pr-4">Unexplained residual</td>
-            <td
-              className={`py-1 text-right ${r.residual !== 0 ? "text-red-500 font-semibold" : ""}`}
-            >
-              {money(r.residual)}
-            </td>
-          </tr>
-          <tr>
-            <td className="py-1 pr-4 text-gray-500">
-              Paid out to bank ({r.payouts.count})
-            </td>
-            <td className="py-1 text-right text-gray-500">
-              {money(r.payouts.amount)}
-            </td>
-          </tr>
-          {r.unclassifiedMemberships > 0 && (
-            <tr>
-              <td className="py-1 pr-4 text-gray-500">
-                Memberships with no matching payment, excluded from the counts
-                above
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <tbody>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Landmedlemskap / Land memberships</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                {inv.quantity.toFixed(2)} × {money(inv.unitPriceExclVat)}
               </td>
-              <td className="py-1 text-right text-gray-500">
-                {r.unclassifiedMemberships}
-              </td>
+              <td className="py-1 text-right">{money(inv.linesExclVat)}</td>
             </tr>
-          )}
-        </tbody>
-      </table>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Refunds on Alversjö memberships</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                −{inv.refundedUnits.toFixed(2)} × {money(inv.unitPriceExclVat)}
+              </td>
+              <td className="py-1 text-right">{money(-inv.refundExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Banking (Stripe) fees</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                {money(inv.feesInclVat)} ÷ {1 + ALVERSJO_VAT_RATE}
+              </td>
+              <td className="py-1 text-right">{money(-inv.feesExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Excl. VAT</td>
+              <td />
+              <td className="py-1 text-right">{money(inv.subtotalExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">VAT {ALVERSJO_VAT_RATE * 100}%</td>
+              <td />
+              <td className="py-1 text-right">{money(inv.vat)}</td>
+            </tr>
+            <tr className="font-semibold">
+              <td className="py-1 pr-4">Total</td>
+              <td />
+              <td className="py-1 text-right">{money(inv.totalInclVat)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
 
       <div className={`text-xs mt-4 ${stale ? "text-red-500" : "text-gray-500"}`}>
         {data.lastSyncedAt

--- a/docs/superpowers/plans/2026-07-29-finances-bl2026-only.md
+++ b/docs/superpowers/plans/2026-07-29-finances-bl2026-only.md
@@ -1,0 +1,725 @@
+# BL-2026-only Finances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the finances section describe BL 2026 and nothing else, show what added to and took from the burn's money, and produce the Alversjö invoice lines directly.
+
+**Architecture:** All changes sit in the existing pure aggregation layer (`utils/stripe/attribution.ts`) and its two consumers — the finances route and the React section. No schema change, no new query; the route in fact loses one. Every figure already exists per payment; the work is stopping some of it being discarded and stopping one of it being wrong.
+
+**Tech Stack:** TypeScript, vitest 3, Next.js 15 App Router, NextUI 2.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md` — read it first, particularly the two refund rules, which are the only subtle parts.
+
+## Global Constraints
+
+- **Amounts are Stripe minor units** (öre) throughout the aggregation layer. Convert only in React, via `formatMoney(amount, currency)`.
+- **Alversjö addon price comes from `burn_config.membership_addons`**, id `alversjo-membership`. Never hardcode 600 or 480.
+- **VAT is 25%**, a named constant `ALVERSJO_VAT_RATE = 0.25` in `utils/stripe/types.ts`. Not configurable.
+- **Alversjö's share of refunds is capped at `alversjoGross`.** It can never give back more than it received; the excess falls to the base membership.
+- **Retained transfer fees count towards Alversjö**, unconditionally, on every refund. No special-casing on whether the transfer recipient also bought the addon.
+- **The Alversjö invoice covers spring memberships but both sales' Stripe fees**, because fall was invoiced gross at 112,800.00 and its fee was never deducted.
+- Existing tests that describe the reconciliation block are **deleted, not adapted** — the behaviour they cover ceases to exist.
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `utils/stripe/types.ts` | `SaleTotals`: add `chargebacks`, `alversjoGross`, `alversjoRefunded`, `alversjoFee`; rename `netAfterFees` → `netKept`. `FinancesPayload`: drop `reconciliation`, add `carerMemberships` and `alversjoInvoice`. Delete `BalanceSummary`. Add `ALVERSJO_VAT_RATE`. |
+| `utils/stripe/attribution.ts` | `splitPayment`: cap Alversjö refunds, stop deducting disputes. `aggregateFinances`: drop `balanceSummary` and unattributed accounting, add carer counting, build the invoice. |
+| `utils/stripe/attribution.test.ts` | Delete reconciliation tests; add tests for the cap, chargebacks, carers, invoice. |
+| `app/api/burn/[slug]/statistics/finances/route.ts` | Stop querying `stripe_balance_transactions`. |
+| `app/burn/[slug]/statistics/FinancesSection.tsx` | New row order, chargeback row, carer line, invoice block; reconciliation block deleted. |
+
+Five tasks, each independently testable. Tasks 1–3 are pure functions with tests; 4 and 5 are the consumers.
+
+---
+
+### Task 1: Cap Alversjö's share of refunds
+
+The bug: a payment of 2,822 (2,222 membership + 600 addon) whose addon was
+cancelled and refunded separately, and which was later transferred, has the 600
+attributed wholly to Alversjö **and** a proportional slice of the transfer refund
+taken from Alversjö too. Its net goes negative. Six BL 2026 payments are affected
+and Alversjö is under-credited by 2,274.78 kr.
+
+**Files:**
+- Modify: `utils/stripe/attribution.ts` (`splitPayment`)
+- Modify: `utils/stripe/attribution.test.ts`
+
+**Interfaces:**
+- Consumes: `MembershipPaymentRow`, `PaymentSplit` (unchanged shapes).
+- Produces: `splitPayment` with `alversjoRefunded <= alversjoGross` always.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `describe("splitPayment", ...)` block:
+
+```typescript
+  it("never takes back more from Alversjö than it received", () => {
+    // Real shape: 2822 paid, the 600 addon cancelled and refunded on its own,
+    // then the membership transferred with a further partial refund. Alversjö
+    // must not be charged for the addon twice.
+    const s = splitPayment(
+      row({
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+        refunds: [{ amount: 60_000 }, { amount: 141_100 }],
+      }),
+      ALVERSJO,
+    );
+    expect(s.alversjoRefunded).toBe(60_000);
+    expect(s.alversjoNet).toBe(0);
+    // the remainder belongs to the base membership
+    expect(s.baseRefunded).toBe(141_100);
+    expect(s.baseNet).toBe(222_200 - 141_100);
+    expect(s.baseRefunded + s.alversjoRefunded).toBe(201_100);
+  });
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run utils/stripe/attribution.test.ts -t "never takes back more"`
+Expected: FAIL — `alversjoRefunded` is 90,000 (60,000 + a 30,000 share of the
+second refund), so `alversjoNet` is −30,000.
+
+- [ ] **Step 3: Apply the cap**
+
+In `utils/stripe/attribution.ts`, replace the refund loop and the line computing
+`baseRefunded`:
+
+```typescript
+  let alversjoRefunded = 0;
+  let refundedTotal = 0;
+  for (const refund of row.refunds) {
+    refundedTotal += refund.amount;
+    alversjoRefunded +=
+      alversjoGross > 0 && refund.amount === alversjoGross
+        ? refund.amount
+        : alversjoShare(refund.amount, alversjoGross, total);
+  }
+  // Alversjö can never give back more than it received. A payment whose addon
+  // was refunded on its own and which was later transferred would otherwise be
+  // charged for the addon twice and go negative.
+  alversjoRefunded = Math.min(alversjoRefunded, alversjoGross);
+  const baseRefunded = refundedTotal - alversjoRefunded;
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npm test`
+Expected: PASS. The existing "50% + addon refund shape" test still passes — its
+refunds sum to 201,100 in one refund rather than two, so the cap does not bind.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/stripe/attribution.ts utils/stripe/attribution.test.ts
+git commit -m "fix: stop charging Alversjö twice for a separately refunded addon"
+```
+
+---
+
+### Task 2: Chargebacks become their own deduction
+
+A chargeback is money lost. Today it is silently subtracted inside operating
+income, which is why the current "Disputes" line reads as unrelated to the rows
+around it.
+
+**Files:**
+- Modify: `utils/stripe/types.ts` (`SaleTotals`, `PaymentSplit`)
+- Modify: `utils/stripe/attribution.ts` (`splitPayment`, `emptyTotals`, `addInto`, `aggregateFinances`)
+- Modify: `utils/stripe/attribution.test.ts`
+
+**Interfaces:**
+- Produces: `PaymentSplit` gains `chargeback: number` (disputed amount + dispute
+  fee). `SaleTotals` gains `chargebacks: number` and renames `netAfterFees` to
+  `netKept`. `splitPayment` no longer subtracts disputes from `baseNet` /
+  `alversjoNet`, and `netFee` no longer includes `dispute_fee`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing `"deducts disputed amounts from net income"` test with:
+
+```typescript
+  it("reports a chargeback separately instead of hiding it in income", () => {
+    // Real case: the one disputed 2222 SEK charge, plus its 200 SEK dispute fee.
+    const s = splitPayment(
+      row({ disputed_amount: 222_200, dispute_fee: 20_000 }),
+      ALVERSJO,
+    );
+    expect(s.baseNet).toBe(222_200); // income untouched
+    expect(s.netFee).toBe(3_513); // dispute fee not folded into the fee
+    expect(s.chargeback).toBe(242_200); // amount plus fee
+  });
+```
+
+and update the fee test in the same block:
+
+```typescript
+  it("nets fee refunds into the fee", () => {
+    const s = splitPayment(row({ fee: 3_513, fee_refunded: -1_200 }), ALVERSJO);
+    expect(s.netFee).toBe(3_513 - 1_200);
+  });
+```
+
+Then, inside `describe("aggregateFinances", ...)`, add:
+
+```typescript
+  it("subtracts chargebacks after income rather than inside it", () => {
+    const p = aggregate([
+      row({
+        paid_at: "2026-03-01T09:00:00Z",
+        amount_total: 222_200,
+        fee: 3_513,
+        disputed_amount: 222_200,
+        dispute_fee: 20_000,
+      }),
+    ]);
+    expect(p.spring.operatingIncome).toBe(222_200);
+    expect(p.spring.stripeFees).toBe(3_513);
+    expect(p.spring.chargebacks).toBe(242_200);
+    expect(p.spring.netKept).toBe(222_200 - 3_513 - 242_200);
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run utils/stripe/attribution.test.ts`
+Expected: FAIL — `chargeback` and `chargebacks` do not exist, `netKept` does not
+exist.
+
+- [ ] **Step 3: Update the types**
+
+In `utils/stripe/types.ts`, add to `PaymentSplit`:
+
+```typescript
+  /** Money the cardholder's bank took back, plus Stripe's dispute fee. */
+  chargeback: number;
+```
+
+and in `SaleTotals` replace `netAfterFees: number;` with:
+
+```typescript
+  /** Money taken back by cardholders, including Stripe's dispute fees. */
+  chargebacks: number;
+  /** operatingIncome − stripeFees − chargebacks. */
+  netKept: number;
+```
+
+- [ ] **Step 4: Update splitPayment**
+
+In `utils/stripe/attribution.ts`, replace the dispute handling and the return:
+
+```typescript
+  const netFee = row.fee + row.fee_refunded;
+  const alversjoFee = alversjoShare(netFee, alversjoGross, total);
+  const baseFee = netFee - alversjoFee;
+
+  return {
+    baseGross,
+    alversjoGross,
+    baseRefunded,
+    alversjoRefunded,
+    // Disputes are not deducted here. They are money taken back after the fact,
+    // reported on their own line so income does not quietly absorb them.
+    baseNet: baseGross - baseRefunded,
+    alversjoNet: alversjoGross - alversjoRefunded,
+    baseFee,
+    alversjoFee,
+    netFee,
+    chargeback: row.disputed_amount + row.dispute_fee,
+  };
+```
+
+Delete the now-unused `alversjoDisputed` and `baseDisputed` lines.
+
+- [ ] **Step 5: Update the aggregator**
+
+In `emptyTotals()` replace `netAfterFees: 0,` with `chargebacks: 0,` and
+`netKept: 0,`. In `addInto()` replace the `netAfterFees` line with:
+
+```typescript
+  target.chargebacks += source.chargebacks;
+  target.netKept += source.netKept;
+```
+
+In the per-row loop of `aggregateFinances`, replace the `totals.netAfterFees`
+line with:
+
+```typescript
+    totals.chargebacks += split.chargeback;
+    totals.netKept +=
+      split.baseNet + split.alversjoNet - split.netFee - split.chargeback;
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add utils/stripe/types.ts utils/stripe/attribution.ts utils/stripe/attribution.test.ts
+git commit -m "feat: show chargebacks as money out instead of hiding them in income"
+```
+
+---
+
+### Task 3: Drop the reconciliation, add carers and the Alversjö invoice
+
+**Files:**
+- Modify: `utils/stripe/types.ts` (`SaleTotals`, `FinancesPayload`, delete `BalanceSummary`, add `ALVERSJO_VAT_RATE`, `AlversjoInvoice`)
+- Modify: `utils/stripe/attribution.ts` (`aggregateFinances`)
+- Modify: `utils/stripe/attribution.test.ts`
+
+**Interfaces:**
+- Consumes: `PaymentSplit.chargeback`, `SaleTotals.netKept` from Task 2.
+- Produces: `aggregateFinances` without the `balanceSummary` input; payload with
+  `carerMemberships: number` and `alversjoInvoice: AlversjoInvoice`, and no
+  `reconciliation`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Delete these four tests from `describe("aggregateFinances", ...)`, whose
+behaviour no longer exists: `"excludes payments belonging to another project and
+counts them as unattributed"`, `"reconciles other burns' payments net, not
+gross"`, `"reconciles to zero when every movement is accounted for"`, and
+`"surfaces a non-zero residual rather than hiding it"`.
+
+Replace the first of them with:
+
+```typescript
+  it("ignores payments belonging to another burn entirely", () => {
+    const p = aggregate([
+      row({ paid_at: "2026-03-01T09:00:00Z", amount_total: 222_200 }),
+      row({ paid_at: "2026-03-02T09:00:00Z", amount_total: 1_000, project_id: null }),
+      row({ paid_at: "2026-03-03T09:00:00Z", amount_total: 3_000, project_id: "other" }),
+    ]);
+    expect(p.total.operatingIncome).toBe(222_200);
+    expect(p.total.payments).toBe(1);
+  });
+```
+
+Update the carer test to assert the new field, and add the invoice tests:
+
+```typescript
+  it("counts carer memberships in the total but in neither sale", () => {
+    const p = aggregate([row({ payment_intent_id: "pi_known" })], {
+      memberships: [
+        { paymentIntentId: "pi_known", checkedIn: false },
+        { paymentIntentId: null, checkedIn: true },
+        { paymentIntentId: "pi_not_in_mirror", checkedIn: false },
+      ],
+    });
+    expect(p.fall.memberships).toBe(0);
+    expect(p.spring.memberships).toBe(1);
+    expect(p.total.memberships).toBe(3); // 1 payment-backed + 2 carers
+    expect(p.total.checkedIn).toBe(1); // the carer who checked in
+    expect(p.carerMemberships).toBe(2);
+  });
+
+  it("builds the Alversjö invoice from spring memberships and both sales' fees", () => {
+    const p = aggregate([
+      // fall: one addon, no refund
+      row({
+        paid_at: "2025-11-20T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+      }),
+      // spring: two addons, one of them refunded in full
+      row({
+        paid_at: "2026-03-01T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+      }),
+      row({
+        paid_at: "2026-03-02T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+        refunds: [{ amount: 60_000 }],
+      }),
+    ]);
+    const inv = p.alversjoInvoice;
+    expect(inv.unitPriceExclVat).toBe(48_000); // 60000 / 1.25
+    expect(inv.quantity).toBe(2); // spring only
+    expect(inv.refundedUnits).toBeCloseTo(1, 4);
+    // fees: 938 per payment (4413 * 60000/282200), three payments
+    expect(inv.feesInclVat).toBe(938 * 3);
+    expect(inv.totalInclVat).toBe(60_000 * 1 - 938 * 3);
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run utils/stripe/attribution.test.ts`
+Expected: FAIL — `carerMemberships` and `alversjoInvoice` do not exist.
+
+- [ ] **Step 3: Update the types**
+
+In `utils/stripe/types.ts`, delete the `BalanceSummary` type, add to `SaleTotals`:
+
+```typescript
+  /** Alversjö addon sold, before refunds. */
+  alversjoGross: number;
+  /** Alversjö's share of refunds, capped at what it received. */
+  alversjoRefunded: number;
+  /** Alversjö's share of Stripe fees, prorated by amount. */
+  alversjoFee: number;
+```
+
+and add:
+
+```typescript
+/** Swedish VAT on the land membership supply. Does not vary. */
+export const ALVERSJO_VAT_RATE = 0.25;
+
+/**
+ * The invoice Alversjö sends BL for land memberships. Covers the spring
+ * memberships only - fall was already invoiced gross - but both sales' Stripe
+ * fees, because fall's were never deducted. All amounts in minor units.
+ */
+export type AlversjoInvoice = {
+  quantity: number;
+  unitPriceExclVat: number;
+  linesExclVat: number;
+  refundedUnits: number;
+  refundExclVat: number;
+  /** The real fee. Divided by 1 + VAT on the invoice so it comes off after VAT. */
+  feesInclVat: number;
+  feesExclVat: number;
+  subtotalExclVat: number;
+  vat: number;
+  totalInclVat: number;
+};
+```
+
+Then replace the `reconciliation` block in `FinancesPayload` with:
+
+```typescript
+  /** Free memberships with no Stripe payment, for carers. Counted in the total. */
+  carerMemberships: number;
+  alversjoInvoice: AlversjoInvoice;
+```
+
+- [ ] **Step 4: Update the aggregator**
+
+In `aggregateFinances`: drop `balanceSummary` from the input type, delete
+`unattributedCount` / `unattributedAmount` / `unattributedNet` /
+`disputeCount` / `disputeAmount` / `disputeFees` and the block that populates
+them, and replace the project-mismatch branch with a plain `continue`:
+
+```typescript
+    if (row.project_id !== input.projectId) continue;
+```
+
+Accumulate the Alversjö detail in the per-row loop, beside the existing lines:
+
+```typescript
+    totals.alversjoGross += split.alversjoGross;
+    totals.alversjoRefunded += split.alversjoRefunded;
+    totals.alversjoFee += split.alversjoFee;
+```
+
+Change carer counting so they land in the total. Replace the
+`unclassifiedMemberships++` line with:
+
+```typescript
+      carerMemberships++;
+      if (membership.checkedIn) carerCheckedIn++;
+      continue;
+```
+
+declaring `let carerMemberships = 0;` and `let carerCheckedIn = 0;` beside the
+other counters, and after `addInto(total, sales.spring)` add:
+
+```typescript
+  // Carer memberships are free and have no payment, so they cannot be dated to a
+  // sale. They are real people who were on site, so they count in the total -
+  // including their check-ins, or the checked-in percentage would be wrong.
+  total.memberships += carerMemberships;
+  total.checkedIn += carerCheckedIn;
+```
+
+Then build the invoice and return it:
+
+```typescript
+  const vatDivisor = 1 + ALVERSJO_VAT_RATE;
+  const exclVat = (n: number) => Math.round(n / vatDivisor);
+  const unitPriceExclVat = exclVat(input.alversjoPrice);
+  // Spring memberships only: fall was already invoiced gross at its full value.
+  const quantity = sales.spring.alversjoGross / input.alversjoPrice;
+  const linesExclVat = Math.round(quantity * unitPriceExclVat);
+  const refundExclVat = exclVat(sales.spring.alversjoRefunded);
+  // Both sales' fees: fall's were never deducted when fall was invoiced.
+  const feesInclVat = sales.fall.alversjoFee + sales.spring.alversjoFee;
+  const feesExclVat = exclVat(feesInclVat);
+  const subtotalExclVat = linesExclVat - refundExclVat - feesExclVat;
+  const vat = Math.round(subtotalExclVat * ALVERSJO_VAT_RATE);
+
+  const alversjoInvoice: AlversjoInvoice = {
+    quantity,
+    unitPriceExclVat,
+    linesExclVat,
+    refundedUnits: unitPriceExclVat
+      ? refundExclVat / unitPriceExclVat
+      : 0,
+    refundExclVat,
+    feesInclVat,
+    feesExclVat,
+    subtotalExclVat,
+    vat,
+    totalInclVat: subtotalExclVat + vat,
+  };
+```
+
+Return `carerMemberships` and `alversjoInvoice` in place of `reconciliation`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/stripe/types.ts utils/stripe/attribution.ts utils/stripe/attribution.test.ts
+git commit -m "feat: scope finances to this burn and derive the Alversjö invoice"
+```
+
+---
+
+### Task 4: Drop the balance-transaction query from the route
+
+The account-wide balance summary existed only to feed the reconciliation block.
+With that gone the route stops fetching ~14,500 rows it no longer uses.
+
+**Files:**
+- Modify: `app/api/burn/[slug]/statistics/finances/route.ts`
+
+**Interfaces:**
+- Consumes: `aggregateFinances` without `balanceSummary` (Task 3).
+
+- [ ] **Step 1: Remove the balance summary**
+
+Delete the `emptyBalance` constant, the `stripe_balance_transactions` query, the
+`balanceSummary` object and the loop that fills it. Delete `BalanceSummary` from
+the import.
+
+The early return for "never synced" becomes:
+
+```typescript
+    if (!lastRun) {
+      return aggregateFinances({
+        rows: [],
+        projectId: project!.id,
+        alversjoPrice,
+        eventEndDate: new Date(burnConfig.event_end_date ?? Date.now()),
+        currency,
+        transfers: [],
+        memberships: [],
+        lastSyncedAt: null,
+      });
+    }
+```
+
+and the final call drops its `balanceSummary` line.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. If `lastRun.stripe_account_id` is now unused, narrow the
+select to `finished_at`.
+
+- [ ] **Step 3: Verify against production**
+
+Run the finances endpoint as a signed-in user and check the figures. The
+statistics page requires a membership or `BurnRole.Admin`.
+
+Expected, for `the-borderland-2026`: `spring.operatingIncome` is **2,222.00 SEK
+higher** than before this change (the chargeback no longer hidden inside it),
+`spring.chargebacks` is `242200`, `total.memberships` is `5443`,
+`carerMemberships` is `5`, and `alversjoInvoice.totalInclVat` is `10571983`
+(105,719.83 SEK).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "app/api/burn/[slug]/statistics/finances/route.ts"
+git commit -m "perf: stop fetching balance transactions the finances page no longer uses"
+```
+
+---
+
+### Task 5: Rebuild the finances section UI
+
+**Files:**
+- Modify: `app/burn/[slug]/statistics/FinancesSection.tsx`
+
+**Interfaces:**
+- Consumes: `FinancesPayload` with `carerMemberships` and `alversjoInvoice`,
+  `SaleTotals` with `chargebacks` and `netKept` (Tasks 2–3).
+
+- [ ] **Step 1: Reorder the table and add the chargeback row**
+
+Replace the `rows` array with:
+
+```tsx
+  const rows: {
+    label: string;
+    get: (t: SaleTotals) => string;
+    strong?: boolean;
+  }[] = [
+    {
+      label: "Membership income (excl. Alversjö)",
+      get: (t) => money(t.membershipIncome),
+    },
+    { label: "Alversjö income", get: (t) => money(t.alversjoIncome) },
+    {
+      label: "Operating income (payments − refunds)",
+      get: (t) => money(t.operatingIncome),
+      strong: true,
+    },
+    { label: "Stripe fees", get: (t) => money(-t.stripeFees) },
+    { label: "Chargebacks", get: (t) => money(-t.chargebacks) },
+    { label: "Net kept", get: (t) => money(t.netKept), strong: true },
+    { label: "Memberships", get: (t) => String(t.memberships) },
+    {
+      label: "Checked in",
+      get: (t) =>
+        t.memberships > 0
+          ? `${t.checkedIn} (${Math.round((t.checkedIn / t.memberships) * 100)}%)`
+          : String(t.checkedIn),
+    },
+    { label: "Payments", get: (t) => String(t.payments) },
+    { label: "Refunds", get: (t) => String(t.refunds) },
+    { label: "Membership transfers", get: (t) => String(t.transfers) },
+    {
+      label: "Surplus from transfers",
+      get: (t) => money(t.transferSurplus),
+    },
+  ];
+```
+
+Fees and chargebacks are negated so the column reads as money out.
+
+- [ ] **Step 2: Replace the intro text and delete the reconciliation block**
+
+Change the paragraph under the heading to:
+
+```tsx
+      <p className="text-xs sm:text-sm text-gray-500 mb-4">
+        Taken directly from Stripe, for this burn only. Operating income is
+        payments less refunds, before fees. Chargebacks are payments reversed by
+        the cardholder&apos;s bank, including Stripe&apos;s fee for them.
+      </p>
+```
+
+Delete everything from `<h3 ...>Reconciliation</h3>` down to the closing
+`</table>` of that second table, and the `const r = data.reconciliation;` line.
+
+- [ ] **Step 3: Add the carer line under the table**
+
+Immediately after the closing `</div>` of the table's `overflow-x-auto` wrapper:
+
+```tsx
+      {data.carerMemberships > 0 && (
+        <p className="text-xs text-gray-500 mt-2">
+          Of the total, {data.carerMemberships} are free carer memberships for
+          people supporting a person with a disability. They have no payment, so
+          they appear only in the total.
+        </p>
+      )}
+```
+
+- [ ] **Step 4: Add the Alversjö invoice block**
+
+Before the last-synced footer:
+
+```tsx
+      <h3 className="text-sm font-semibold mt-6 mb-1">Alversjö invoice</h3>
+      <p className="text-xs text-gray-500 mb-2">
+        What Alversjö should invoice BL for the land memberships. Covers the
+        spring memberships — the fall ones were already invoiced — and the Stripe
+        fees from both sales, since fall&apos;s were never deducted.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <tbody>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Landmedlemskap / Land memberships</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                {inv.quantity.toFixed(2)} × {money(inv.unitPriceExclVat)}
+              </td>
+              <td className="py-1 text-right">{money(inv.linesExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Refunds on Alversjö memberships</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                −{inv.refundedUnits.toFixed(2)} × {money(inv.unitPriceExclVat)}
+              </td>
+              <td className="py-1 text-right">{money(-inv.refundExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Banking (Stripe) fees</td>
+              <td className="py-1 px-4 text-right text-gray-500">
+                {money(inv.feesInclVat)} ÷ {1 + ALVERSJO_VAT_RATE}
+              </td>
+              <td className="py-1 text-right">{money(-inv.feesExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">Excl. VAT</td>
+              <td />
+              <td className="py-1 text-right">{money(inv.subtotalExclVat)}</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-1 pr-4">
+                VAT {ALVERSJO_VAT_RATE * 100}%
+              </td>
+              <td />
+              <td className="py-1 text-right">{money(inv.vat)}</td>
+            </tr>
+            <tr className="font-semibold">
+              <td className="py-1 pr-4">Total</td>
+              <td />
+              <td className="py-1 text-right">{money(inv.totalInclVat)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+```
+
+Add `const inv = data.alversjoInvoice;` beside the other locals, and import
+`ALVERSJO_VAT_RATE` from `@/utils/stripe/types`.
+
+- [ ] **Step 5: Verify**
+
+Run: `npx tsc --noEmit && npm run lint && npm run build`
+Expected: no errors, no new warnings.
+
+Then open `/burn/the-borderland-2026/statistics` signed in and check: the
+chargeback row shows −2,422.00 in spring, "Net kept" equals operating income less
+fees less chargebacks in every column, the carer line reads 5, and the invoice
+totals **105,719.83**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "app/burn/[slug]/statistics/FinancesSection.tsx"
+git commit -m "feat: money-in/money-out finances table and Alversjö invoice block"
+```
+
+---
+
+## Done
+
+- [ ] `npm test` — all pass
+- [ ] `npx tsc --noEmit` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Live figures: invoice total 105,719.83, memberships 5,443, chargebacks −2,422.00
+
+<!-- PLAN-END -->

--- a/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
+++ b/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
@@ -1,0 +1,116 @@
+# Finances section: BL 2026 only, money in and money out
+
+**Date:** 2026-07-29
+**Status:** Approved design, ready for planning
+
+## Problem
+
+The finances section reports on the whole Stripe account and then explains, in a
+reconciliation block, why most of what it reports is irrelevant. Three of its five
+lines exist only to subtract things that were never BL 2026 in the first place:
+
+- **Payments not belonging to this burn** — 6,037 payments, all from the 2025 burn,
+  which shares the Stripe account.
+- **Other balance transactions** — a pair of ±500 SEK internal transfers, netting
+  to exactly zero.
+- **Unexplained residual** — 1,733.20 SEK, which turned out to be a single Open
+  Collective donation (`ch_3SAQEpEuBjGnolU20J3GqwJc`, 2025-09-23, "Financial
+  contribution to The Borderland", from `eric.reinford@gmail.com`, 2,000.00 gross
+  less a 200.00 Open Collective application fee and 66.80 Stripe fee).
+
+None of that is BL 2026 income. Two further lines are unclear rather than wrong:
+**Sale rows, net of fees** silently restates the table's own Net-after-fees total,
+and **Disputes** shows a figure with no indication whether it is money gained or
+lost, or how it relates to the rows above.
+
+## Decision
+
+The page reports on **BL 2026 and nothing else**, and reads as what added to the
+burn's money and what took from it.
+
+### Removed
+
+The entire reconciliation block, including all five lines above. Payments
+belonging to another burn are skipped rather than counted and subtracted.
+
+**What this gives up:** the page can no longer cross-check its figures against
+total movement in the Stripe account. Previously a mistake in attribution would
+surface as a non-zero residual. After this change it would not — the numbers
+become internally consistent by construction. That is an accepted trade: the
+cross-check was only meaningful while the page pretended to describe the whole
+account.
+
+### The table
+
+Fall / spring / total, in money-in-then-money-out order:
+
+| Row | |
+|---|---|
+| Membership income (excl. Alversjö) | + |
+| Alversjö income | + |
+| **Operating income** (payments − refunds) | **=** |
+| Stripe fees | − |
+| Chargebacks | − |
+| **Net kept** | **=** |
+| Memberships | count |
+| Checked in | count |
+| Payments · Refunds · Membership transfers | counts |
+| Surplus from transfers | |
+
+### Chargebacks become visible
+
+A chargeback is money lost: the cardholder's bank reverses the payment and Stripe
+also charges a fee. BL 2026 has one — 2,222.00 SEK reversed plus a 200.00 SEK fee,
+withdrawn 2026-05-28, still `under_review`.
+
+Today that is deducted silently inside operating income, which is why the current
+"Disputes" line reads as unrelated to everything around it. After this change:
+
+- `splitPayment` stops subtracting `disputed_amount` from the net, and stops
+  folding `dispute_fee` into the fee.
+- `SaleTotals` gains `chargebacks` = disputed amount + dispute fee, shown as its
+  own deduction.
+- `netAfterFees` is replaced by `netKept` = operating income − Stripe fees −
+  chargebacks.
+
+Operating income therefore rises by 2,222.00 against today's figure, and the
+chargeback appears explicitly as −2,422.00. Nothing is counted twice.
+
+### Carer memberships
+
+Five memberships have no Stripe payment: they are free memberships for carers of
+persons with disabilities. Four of the five checked in.
+
+They cannot be dated to a sale, so they stay out of the fall and spring columns,
+but they are counted in the **Total** column so the membership count matches
+reality (5,443, not 5,438). A labelled line beneath reads *"of which carer
+memberships (free): 5"*.
+
+## Implementation
+
+- `utils/stripe/types.ts` — `SaleTotals`: add `chargebacks`, replace
+  `netAfterFees` with `netKept`. `FinancesPayload`: drop `reconciliation`, add
+  `carerMemberships: number`. Drop `BalanceSummary` entirely.
+- `utils/stripe/attribution.ts` — `splitPayment` no longer deducts disputes;
+  `aggregateFinances` drops the `balanceSummary` input and the unattributed
+  accounting, adds carer counting into the total.
+- `app/api/burn/[slug]/statistics/finances/route.ts` — stops querying
+  `stripe_balance_transactions` altogether. One fewer query, ~14.5k fewer rows
+  per request.
+- `app/burn/[slug]/statistics/FinancesSection.tsx` — new row order, chargeback
+  row, carer line, reconciliation block deleted.
+
+## Testing
+
+Existing tests covering the reconciliation block are removed rather than adapted;
+the behaviour they described no longer exists. New tests cover:
+
+- a chargeback appearing as its own deduction and **not** reducing operating
+  income, so the same payment is not counted against the burn twice;
+- `netKept` = operating income − fees − chargebacks;
+- carer memberships counting in the total but in neither sale column;
+- payments belonging to another burn being skipped silently, with no effect on
+  any figure.
+
+Verified against production before shipping: operating income must equal today's
+figure plus 2,222.00, and the membership total must read 5,443.

--- a/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
+++ b/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
@@ -100,6 +100,71 @@ memberships (free): 5"*.
 - `app/burn/[slug]/statistics/FinancesSection.tsx` — new row order, chargeback
   row, carer line, reconciliation block deleted.
 
+## Alversjö invoice block
+
+Alversjö invoices BL for the land memberships sold through BL. Christian has been
+assembling that invoice by hand from a Stripe spreadsheet each time. The page
+should produce its lines directly.
+
+One block, below the finances table, reproducing the line structure of the 2025
+invoice so it can be typed straight into Fortnox:
+
+```
+Landmedlemskap / Land memberships       234,00 pcs ×  480,00 =  112 320,00
+Refunds on Alversjö memberships         −53,71 pcs ×  480,00 =  −25 781,42
+Banking (Stripe) fees (fall + spring)    −1,00      3 782,54 =  − 3 782,54
+
+                                              Excl. VAT          82 756,04
+                                                 VAT 25%         20 689,01
+                                                   Total        103 445,05
+```
+
+### What the block covers, and why
+
+It is the invoice for what is **still outstanding**, not for the whole burn. The
+fall memberships were already invoiced and paid at 112,800.00, so they are
+excluded by simply not counting them — no "already paid" deduction line. But
+fall's Stripe fee was never deducted at the time, so it is carried here.
+
+- **Memberships**: spring sale only, priced at the addon price excl VAT.
+- **Refunds**: the Alversjö share of refunds, expressed as negative units so it
+  reads as a quantity rather than an unexplained deduction. All refunds fall in
+  the spring sale; fall had none.
+- **Stripe fees**: fall plus spring, prorated per payment by each payment's
+  Alversjö share of that payment's total.
+
+Cross-check: 108,173.22 spring net − 1,951.87 fall fee − 2,776.31 spring fee =
+103,445.04, matching the block total to the öre.
+
+### VAT
+
+The fee line is written as `fee ÷ 1.25` so that the full fee comes off the
+VAT-inclusive total, exactly as the 2025 invoice was constructed (`5,640.07 ÷
+1.25 = 4,512.06`, giving 310,500.00 − 5,640.07 = 304,860.00). VAT is 25%, a named
+constant — Swedish VAT on this supply does not vary, and a config field for it
+would be speculative.
+
+### Derived, not entered
+
+The unit price is the addon price from `burn_config` divided by 1.25, not the
+literal 480. Quantities, refunds and fees all come from figures the aggregator
+already computes per payment; the block adds no new data source.
+
+This requires exposing three values per sale that are currently computed and
+discarded: Alversjö gross, Alversjö refunded, and the Alversjö fee share. Today
+only the net survives into the payload.
+
+### Known divergence from the 2025 hand calculation
+
+Applying this method to BL 2025 gives 520.76 units and 5,871.61 in fees, against
+Christian's 517.50 and 5,640.07. Not an error on either side: he counted the 508
+surviving memberships plus 9.5 units for nineteen 50%-refund cases found by hand,
+whereas this attributes a proportional share of **every** refund, so the ~3%
+retained on 97%-refund transfers also lands with Alversjö. This method is ~1,954
+kr more favourable to Alversjö and does not depend on spotting special cases
+manually. Worth flagging to Christian, since it means BL 2026 is computed on a
+slightly different basis than BL 2025.
+
 ## Testing
 
 Existing tests covering the reconciliation block are removed rather than adapted;
@@ -110,7 +175,10 @@ the behaviour they described no longer exists. New tests cover:
 - `netKept` = operating income − fees − chargebacks;
 - carer memberships counting in the total but in neither sale column;
 - payments belonging to another burn being skipped silently, with no effect on
-  any figure.
+  any figure;
+- the Alversjö invoice block: quantities and refund units derived from the
+  addon price rather than a literal 480, the fee line carrying both sales, and
+  the block total equalling spring net less both sales' fees.
 
 Verified against production before shipping: operating income must equal today's
 figure plus 2,222.00, and the membership total must read 5,443.

--- a/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
+++ b/docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md
@@ -111,12 +111,12 @@ invoice so it can be typed straight into Fortnox:
 
 ```
 Landmedlemskap / Land memberships       234,00 pcs ×  480,00 =  112 320,00
-Refunds on Alversjö memberships         −53,71 pcs ×  480,00 =  −25 781,42
+Refunds on Alversjö memberships         −49,92 pcs ×  480,00 =  −23 961,60
 Banking (Stripe) fees (fall + spring)    −1,00      3 782,54 =  − 3 782,54
 
-                                              Excl. VAT          82 756,04
-                                                 VAT 25%         20 689,01
-                                                   Total        103 445,05
+                                              Excl. VAT          84 575,86
+                                                 VAT 25%         21 143,97
+                                                   Total        105 719,83
 ```
 
 ### What the block covers, and why
@@ -133,8 +133,8 @@ fall's Stripe fee was never deducted at the time, so it is carried here.
 - **Stripe fees**: fall plus spring, prorated per payment by each payment's
   Alversjö share of that payment's total.
 
-Cross-check: 108,173.22 spring net − 1,951.87 fall fee − 2,776.31 spring fee =
-103,445.04, matching the block total to the öre.
+Cross-check: 110,448.00 spring net − 1,951.87 fall fee − 2,776.31 spring fee =
+105,719.82, matching the block total to the öre.
 
 ### VAT
 
@@ -153,6 +153,38 @@ already computes per payment; the block adds no new data source.
 This requires exposing three values per sale that are currently computed and
 discarded: Alversjö gross, Alversjö refunded, and the Alversjö fee share. Today
 only the net survives into the payload.
+
+### Alversjö's share of a refund is capped at what it received
+
+A payment of 2,822 (2,222 membership + 600 addon) whose addon was cancelled and
+refunded separately, and which was later transferred, currently has the 600
+attributed wholly to Alversjö **and** a proportional slice of the transfer refund
+taken from Alversjö as well. Alversjö is charged twice and its net for that
+payment goes negative, which cannot be right: it can never give back more than it
+received.
+
+`splitPayment` therefore caps Alversjö's share of refunds at `alversjoGross`, with
+any excess falling to the base membership. Six BL 2026 payments are affected - the
+same six hit by the stale-price refund bug - and Alversjö is currently
+under-credited by 2,274.78 kr because of it. Spring net goes from 108,173.22 to
+110,448.00.
+
+A regression test covers exactly this shape: addon refunded in full, then a later
+partial refund, asserting the Alversjö net is zero rather than negative and that
+the base absorbs the remainder.
+
+### Retained transfer fees count towards Alversjö
+
+When a membership with the addon is transferred, BL keeps a transfer fee taken
+from the whole payment, so part of it comes out of the 600. That retained part is
+credited to Alversjö, on every refund, with no special cases.
+
+The alternative - credit it only when the person receiving the transfer did not
+themselves buy the addon - was put to Christian, who judged the amounts too small
+to matter (about 650 kr across BL 2026) and left the choice open. One
+unconditional rule is preferred because it does not depend on pairing each
+transfer to its replacement payment, and three BL 2026 transfers cannot be paired
+at all.
 
 ### Known divergence from the 2025 hand calculation
 

--- a/utils/stripe/attribution.test.ts
+++ b/utils/stripe/attribution.test.ts
@@ -161,11 +161,33 @@ describe("splitPayment", () => {
       }),
       ALVERSJO,
     );
-    // first is addon-sized -> all Alversjö; second splits proportionally
-    expect(s.alversjoRefunded).toBe(
-      60_000 + Math.round((111_100 * 60_000) / 282_200),
-    );
+    // The first refund is addon-sized, so it clears Alversjö's whole 600. The
+    // second cannot take any more from Alversjö - it has nothing left to give
+    // back - so it falls entirely to the base membership.
+    expect(s.alversjoRefunded).toBe(60_000);
+    expect(s.baseRefunded).toBe(111_100);
     expect(s.baseRefunded + s.alversjoRefunded).toBe(171_100);
+  });
+
+  it("never takes back more from Alversjö than it received", () => {
+    // Real shape: 2822 paid, the 600 addon cancelled and refunded on its own,
+    // then the membership transferred with a further partial refund. Alversjö
+    // must not be charged for the addon twice.
+    const s = splitPayment(
+      row({
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+        refunds: [{ amount: 60_000 }, { amount: 141_100 }],
+      }),
+      ALVERSJO,
+    );
+    expect(s.alversjoRefunded).toBe(60_000);
+    expect(s.alversjoNet).toBe(0);
+    // the remainder belongs to the base membership
+    expect(s.baseRefunded).toBe(141_100);
+    expect(s.baseNet).toBe(222_200 - 141_100);
+    expect(s.baseRefunded + s.alversjoRefunded).toBe(201_100);
   });
 
   it("does not divide by zero on a zero-amount payment", () => {

--- a/utils/stripe/attribution.test.ts
+++ b/utils/stripe/attribution.test.ts
@@ -4,7 +4,7 @@ import {
   classifySale,
   splitPayment,
 } from "@/utils/stripe/attribution";
-import { BalanceSummary, MembershipPaymentRow } from "@/utils/stripe/types";
+import { MembershipPaymentRow } from "@/utils/stripe/types";
 
 const EVENT_END = new Date("2026-07-26T12:00:00Z"); // The Borderland 2026
 const ALVERSJO = 60_000; // 600 SEK in öre
@@ -200,12 +200,6 @@ describe("splitPayment", () => {
 });
 
 const PROJECT = "06101baf-5991-42b1-b2f5-caa9fd6b90e2";
-const EMPTY_BALANCE: BalanceSummary = {
-  netExcludingPayouts: 0,
-  payouts: { count: 0, amount: 0 },
-  other: { count: 0, amount: 0 },
-};
-
 function aggregate(
   rows: MembershipPaymentRow[],
   over: Partial<Parameters<typeof aggregateFinances>[0]> = {},
@@ -218,7 +212,6 @@ function aggregate(
     currency: "SEK",
     transfers: [],
     memberships: [],
-    balanceSummary: EMPTY_BALANCE,
     lastSyncedAt: "2026-07-28T10:00:00Z",
     ...over,
   });
@@ -275,18 +268,7 @@ describe("aggregateFinances", () => {
     expect(p.spring.netKept).toBe(222_200 - 3_513);
   });
 
-  it("excludes payments belonging to another project and counts them as unattributed", () => {
-    const p = aggregate([
-      row({ paid_at: "2026-03-01T09:00:00Z", amount_total: 222_200 }),
-      row({ paid_at: "2026-03-02T09:00:00Z", amount_total: 1_000, project_id: null }),
-      row({ paid_at: "2026-03-03T09:00:00Z", amount_total: 3_000, project_id: "other" }),
-    ]);
-    expect(p.total.operatingIncome).toBe(222_200);
-    expect(p.reconciliation.unattributedPayments.count).toBe(2);
-    expect(p.reconciliation.unattributedPayments.amount).toBe(4_000);
-  });
-
-  it("counts transfers against the sale of the original membership", () => {
+    it("counts transfers against the sale of the original membership", () => {
     const p = aggregate(
       [
         row({ payment_intent_id: "pi_fall", paid_at: "2025-11-20T09:00:00Z" }),
@@ -307,98 +289,7 @@ describe("aggregateFinances", () => {
     expect(p.total.transfers).toBe(1);
   });
 
-  it("reconciles to zero when every movement is accounted for", () => {
-    const p = aggregate(
-      [row({ paid_at: "2026-03-01T09:00:00Z", amount_total: 222_200, fee: 3_513 })],
-      {
-        balanceSummary: {
-          netExcludingPayouts: 222_200 - 3_513,
-          payouts: { count: 1, amount: -200_000 },
-          other: { count: 0, amount: 0 },
-        },
-      },
-    );
-    expect(p.reconciliation.residual).toBe(0);
-    expect(p.reconciliation.payouts).toEqual({ count: 1, amount: -200_000 });
-  });
-
-  it("surfaces a non-zero residual rather than hiding it", () => {
-    const p = aggregate(
-      [row({ paid_at: "2026-03-01T09:00:00Z", amount_total: 222_200, fee: 3_513 })],
-      {
-        balanceSummary: {
-          netExcludingPayouts: 222_200 - 3_513 + 50_000,
-          payouts: { count: 0, amount: 0 },
-          other: { count: 0, amount: 0 },
-        },
-      },
-    );
-    expect(p.reconciliation.residual).toBe(50_000);
-  });
-
-  it("reconciles other burns' payments net, not gross", () => {
-    // A payment from another burn, half refunded, with a fee. Only its NET may
-    // enter the residual arithmetic - counting it gross silently unbalances the
-    // whole reconciliation block.
-    const p = aggregate(
-      [
-        row({
-          paid_at: "2026-03-01T09:00:00Z",
-          project_id: "other-burn",
-          amount_total: 200_000,
-          fee: 3_000,
-          refunds: [{ amount: 100_000 }],
-        }),
-      ],
-      {
-        balanceSummary: {
-          netExcludingPayouts: 200_000 - 100_000 - 3_000,
-          payouts: { count: 0, amount: 0 },
-          other: { count: 0, amount: 0 },
-        },
-      },
-    );
-    expect(p.reconciliation.unattributedPayments.amount).toBe(200_000);
-    expect(p.reconciliation.unattributedPayments.net).toBe(97_000);
-    expect(p.reconciliation.residual).toBe(0);
-  });
-
-  it("prices the transfer surplus against the no-transfer counterfactual", () => {
-    // Real 3% era shape: A paid 2222 (fee 35.13), refunded 2155.34; B paid 2222
-    // (fee 35.13). The burn keeps the 66.66 buffer less B's fee = 31.53.
-    const p = aggregate(
-      [
-        row({
-          payment_intent_id: "pi_A",
-          owner_id: "alice",
-          paid_at: "2026-03-01T09:00:00Z",
-          amount_total: 222_200,
-          fee: 3_513,
-          refunds: [{ amount: 215_534 }],
-        }),
-        row({
-          payment_intent_id: "pi_B",
-          owner_id: "bob",
-          paid_at: "2026-06-01T09:00:00Z",
-          amount_total: 222_200,
-          fee: 3_513,
-        }),
-      ],
-      {
-        transfers: [
-          {
-            fromPaymentIntentId: "pi_A",
-            toOwnerId: "bob",
-            at: "2026-06-01T09:00:00Z",
-          },
-        ],
-      },
-    );
-    expect(p.spring.transferSurplus).toBe(222_200 - 3_513 - 215_534);
-    expect(p.spring.transferSurplus).toBe(3_153);
-  });
-
-  it("reports a negative surplus when the incoming fee exceeds the buffer", () => {
+      it("reports a negative surplus when the incoming fee exceeds the buffer", () => {
     // B pays with an international card: 74.02 fee against a 66.66 buffer.
     const p = aggregate(
       [
@@ -512,7 +403,17 @@ describe("aggregateFinances", () => {
     expect(p.spring.checkedIn).toBe(1);
   });
 
-  it("reports memberships it cannot date rather than dropping them", () => {
+  it("ignores payments belonging to another burn entirely", () => {
+    const p = aggregate([
+      row({ paid_at: "2026-03-01T09:00:00Z", amount_total: 222_200 }),
+      row({ paid_at: "2026-03-02T09:00:00Z", amount_total: 1_000, project_id: null }),
+      row({ paid_at: "2026-03-03T09:00:00Z", amount_total: 3_000, project_id: "other" }),
+    ]);
+    expect(p.total.operatingIncome).toBe(222_200);
+    expect(p.total.payments).toBe(1);
+  });
+
+  it("counts carer memberships in the total but in neither sale", () => {
     const p = aggregate([row({ payment_intent_id: "pi_known" })], {
       memberships: [
         { paymentIntentId: "pi_known", checkedIn: false },
@@ -520,8 +421,44 @@ describe("aggregateFinances", () => {
         { paymentIntentId: "pi_not_in_mirror", checkedIn: false },
       ],
     });
-    expect(p.total.memberships).toBe(1);
-    expect(p.reconciliation.unclassifiedMemberships).toBe(2);
+    expect(p.fall.memberships).toBe(0);
+    expect(p.spring.memberships).toBe(1);
+    expect(p.total.memberships).toBe(3); // 1 payment-backed + 2 carers
+    expect(p.total.checkedIn).toBe(1); // the carer who checked in
+    expect(p.carerMemberships).toBe(2);
+  });
+
+  it("builds the Alversjö invoice from spring memberships and both sales' fees", () => {
+    const p = aggregate([
+      // fall: one addon, no refund
+      row({
+        paid_at: "2025-11-20T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+      }),
+      // spring: two addons, one of them refunded in full
+      row({
+        paid_at: "2026-03-01T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+      }),
+      row({
+        paid_at: "2026-03-02T09:00:00Z",
+        amount_total: 282_200,
+        has_alversjo: true,
+        fee: 4_413,
+        refunds: [{ amount: 60_000 }],
+      }),
+    ]);
+    const inv = p.alversjoInvoice;
+    expect(inv.unitPriceExclVat).toBe(48_000); // 60000 / 1.25
+    expect(inv.quantity).toBe(2); // spring only
+    expect(inv.refundedUnits).toBeCloseTo(1, 4);
+    // fees: 938 per payment (4413 * 60000/282200), three payments
+    expect(inv.feesInclVat).toBe(938 * 3);
+    expect(inv.totalInclVat).toBe(60_000 * 1 - 938 * 3);
   });
 
   it("subtracts chargebacks after income rather than inside it", () => {

--- a/utils/stripe/attribution.test.ts
+++ b/utils/stripe/attribution.test.ts
@@ -138,18 +138,20 @@ describe("splitPayment", () => {
     expect(s.baseNet + s.alversjoNet).toBe(282_200 - 201_100);
   });
 
-  it("nets fee refunds and dispute fees into the fee", () => {
-    const s = splitPayment(
-      row({ fee: 3_513, fee_refunded: -1_200, dispute_fee: 20_000 }),
-      ALVERSJO,
-    );
-    expect(s.netFee).toBe(3_513 - 1_200 + 20_000);
+  it("nets fee refunds into the fee", () => {
+    const s = splitPayment(row({ fee: 3_513, fee_refunded: -1_200 }), ALVERSJO);
+    expect(s.netFee).toBe(3_513 - 1_200);
   });
 
-  it("deducts disputed amounts from net income", () => {
-    // Real case: the one disputed 2222 SEK charge
-    const s = splitPayment(row({ disputed_amount: 222_200 }), ALVERSJO);
-    expect(s.baseNet).toBe(0);
+  it("reports a chargeback separately instead of hiding it in income", () => {
+    // Real case: the one disputed 2222 SEK charge, plus its 200 SEK dispute fee.
+    const s = splitPayment(
+      row({ disputed_amount: 222_200, dispute_fee: 20_000 }),
+      ALVERSJO,
+    );
+    expect(s.baseNet).toBe(222_200); // income untouched
+    expect(s.netFee).toBe(3_513); // dispute fee not folded into the fee
+    expect(s.chargeback).toBe(242_200); // amount plus fee
   });
 
   it("treats multiple refunds on one payment independently", () => {
@@ -270,7 +272,7 @@ describe("aggregateFinances", () => {
     ]);
     expect(p.spring.operatingIncome).toBe(222_200);
     expect(p.spring.stripeFees).toBe(3_513);
-    expect(p.spring.netAfterFees).toBe(222_200 - 3_513);
+    expect(p.spring.netKept).toBe(222_200 - 3_513);
   });
 
   it("excludes payments belonging to another project and counts them as unattributed", () => {
@@ -520,6 +522,22 @@ describe("aggregateFinances", () => {
     });
     expect(p.total.memberships).toBe(1);
     expect(p.reconciliation.unclassifiedMemberships).toBe(2);
+  });
+
+  it("subtracts chargebacks after income rather than inside it", () => {
+    const p = aggregate([
+      row({
+        paid_at: "2026-03-01T09:00:00Z",
+        amount_total: 222_200,
+        fee: 3_513,
+        disputed_amount: 222_200,
+        dispute_fee: 20_000,
+      }),
+    ]);
+    expect(p.spring.operatingIncome).toBe(222_200);
+    expect(p.spring.stripeFees).toBe(3_513);
+    expect(p.spring.chargebacks).toBe(242_200);
+    expect(p.spring.netKept).toBe(222_200 - 3_513 - 242_200);
   });
 
   it("returns zeros for an empty mirror", () => {

--- a/utils/stripe/attribution.ts
+++ b/utils/stripe/attribution.ts
@@ -64,14 +64,7 @@ export function splitPayment(
   alversjoRefunded = Math.min(alversjoRefunded, alversjoGross);
   const baseRefunded = refundedTotal - alversjoRefunded;
 
-  const alversjoDisputed = alversjoShare(
-    row.disputed_amount,
-    alversjoGross,
-    total,
-  );
-  const baseDisputed = row.disputed_amount - alversjoDisputed;
-
-  const netFee = row.fee + row.fee_refunded + row.dispute_fee;
+  const netFee = row.fee + row.fee_refunded;
   const alversjoFee = alversjoShare(netFee, alversjoGross, total);
   const baseFee = netFee - alversjoFee;
 
@@ -80,11 +73,14 @@ export function splitPayment(
     alversjoGross,
     baseRefunded,
     alversjoRefunded,
-    baseNet: baseGross - baseRefunded - baseDisputed,
-    alversjoNet: alversjoGross - alversjoRefunded - alversjoDisputed,
+    // Disputes are not deducted here. They are money taken back after the fact,
+    // reported on their own line so income does not quietly absorb them.
+    baseNet: baseGross - baseRefunded,
+    alversjoNet: alversjoGross - alversjoRefunded,
     baseFee,
     alversjoFee,
     netFee,
+    chargeback: row.disputed_amount + row.dispute_fee,
   };
 }
 
@@ -94,7 +90,8 @@ function emptyTotals(): SaleTotals {
     alversjoIncome: 0,
     operatingIncome: 0,
     stripeFees: 0,
-    netAfterFees: 0,
+    chargebacks: 0,
+    netKept: 0,
     payments: 0,
     refunds: 0,
     transfers: 0,
@@ -109,7 +106,8 @@ function addInto(target: SaleTotals, source: SaleTotals) {
   target.alversjoIncome += source.alversjoIncome;
   target.operatingIncome += source.operatingIncome;
   target.stripeFees += source.stripeFees;
-  target.netAfterFees += source.netAfterFees;
+  target.chargebacks += source.chargebacks;
+  target.netKept += source.netKept;
   target.payments += source.payments;
   target.refunds += source.refunds;
   target.transfers += source.transfers;
@@ -200,7 +198,9 @@ export function aggregateFinances(input: {
     totals.alversjoIncome += split.alversjoNet;
     totals.operatingIncome += split.baseNet + split.alversjoNet;
     totals.stripeFees += split.netFee;
-    totals.netAfterFees += split.baseNet + split.alversjoNet - split.netFee;
+    totals.chargebacks += split.chargeback;
+    totals.netKept +=
+      split.baseNet + split.alversjoNet - split.netFee - split.chargeback;
     totals.payments++;
     if (row.refunds.length > 0) totals.refunds++;
     if (row.payment_intent_id && transfers.has(row.payment_intent_id)) {
@@ -268,7 +268,7 @@ export function aggregateFinances(input: {
   // kept, less the fees paid on it. Dispute amounts and fees are already inside the
   // sale rows (splitPayment deducts them), so they are reported for visibility but
   // not subtracted again here.
-  const saleRowsNet = total.netAfterFees;
+  const saleRowsNet = total.netKept;
   const accountedFor =
     saleRowsNet + unattributedNet + input.balanceSummary.other.amount;
 

--- a/utils/stripe/attribution.ts
+++ b/utils/stripe/attribution.ts
@@ -1,5 +1,6 @@
 import {
-  BalanceSummary,
+  AlversjoInvoice,
+  ALVERSJO_VAT_RATE,
   FinancesPayload,
   MembershipCountInput,
   MembershipPaymentRow,
@@ -98,6 +99,9 @@ function emptyTotals(): SaleTotals {
     transferSurplus: 0,
     memberships: 0,
     checkedIn: 0,
+    alversjoGross: 0,
+    alversjoRefunded: 0,
+    alversjoFee: 0,
   };
 }
 
@@ -114,6 +118,9 @@ function addInto(target: SaleTotals, source: SaleTotals) {
   target.transferSurplus += source.transferSurplus;
   target.memberships += source.memberships;
   target.checkedIn += source.checkedIn;
+  target.alversjoGross += source.alversjoGross;
+  target.alversjoRefunded += source.alversjoRefunded;
+  target.alversjoFee += source.alversjoFee;
 }
 
 /** Total refunded on a payment. */
@@ -140,7 +147,6 @@ export function aggregateFinances(input: {
   currency: string;
   transfers: TransferInput[];
   memberships: MembershipCountInput[];
-  balanceSummary: BalanceSummary;
   lastSyncedAt: string | null;
 }): FinancesPayload {
   const sales: Record<SaleKey, SaleTotals> = {
@@ -161,34 +167,11 @@ export function aggregateFinances(input: {
     input.transfers.map((t) => t.fromPaymentIntentId).filter(Boolean) as string[],
   );
 
-  let unattributedCount = 0;
-  let unattributedAmount = 0;
-  let unattributedNet = 0;
-  let disputeCount = 0;
-  let disputeAmount = 0;
-  let disputeFees = 0;
+  let carerMemberships = 0;
+  let carerCheckedIn = 0;
 
   for (const row of input.rows) {
-    if (row.disputed_amount > 0 || row.dispute_fee > 0) {
-      disputeCount++;
-      disputeAmount += row.disputed_amount;
-      disputeFees += row.dispute_fee;
-    }
-
-    if (row.project_id !== input.projectId) {
-      unattributedCount++;
-      unattributedAmount += row.amount_total;
-      // Net on the same basis as the sale rows, so the residual compares like
-      // with like. The Alversjö split is irrelevant here — it redistributes
-      // within a payment without changing its net.
-      const refunded = row.refunds.reduce((a, r) => a + r.amount, 0);
-      unattributedNet +=
-        row.amount_total -
-        refunded -
-        row.disputed_amount -
-        (row.fee + row.fee_refunded + row.dispute_fee);
-      continue;
-    }
+    if (row.project_id !== input.projectId) continue;
 
     const sale = classifySale(new Date(row.paid_at), input.eventEndDate);
     const split = splitPayment(row, input.alversjoPrice);
@@ -198,6 +181,9 @@ export function aggregateFinances(input: {
     totals.alversjoIncome += split.alversjoNet;
     totals.operatingIncome += split.baseNet + split.alversjoNet;
     totals.stripeFees += split.netFee;
+    totals.alversjoGross += split.alversjoGross;
+    totals.alversjoRefunded += split.alversjoRefunded;
+    totals.alversjoFee += split.alversjoFee;
     totals.chargebacks += split.chargeback;
     totals.netKept +=
       split.baseNet + split.alversjoNet - split.netFee - split.chargeback;
@@ -245,13 +231,13 @@ export function aggregateFinances(input: {
   // A membership acquired by transfer is dated by the payment that acquired it,
   // not by the original holder's purchase, which is what makes the counts add up
   // against the payments above.
-  let unclassifiedMemberships = 0;
   for (const membership of input.memberships) {
     const payment = membership.paymentIntentId
       ? byPaymentIntent.get(membership.paymentIntentId)
       : undefined;
     if (!payment) {
-      unclassifiedMemberships++;
+      carerMemberships++;
+      if (membership.checkedIn) carerCheckedIn++;
       continue;
     }
     const totals =
@@ -264,37 +250,47 @@ export function aggregateFinances(input: {
   addInto(total, sales.fall);
   addInto(total, sales.spring);
 
-  // Everything the sale rows account for, in balance-sheet terms: income actually
-  // kept, less the fees paid on it. Dispute amounts and fees are already inside the
-  // sale rows (splitPayment deducts them), so they are reported for visibility but
-  // not subtracted again here.
-  const saleRowsNet = total.netKept;
-  const accountedFor =
-    saleRowsNet + unattributedNet + input.balanceSummary.other.amount;
+  // Carer memberships are free and have no payment, so they cannot be dated to a
+  // sale. They are real people who were on site, so they count in the total -
+  // including their check-ins, or the checked-in percentage would be wrong.
+  total.memberships += carerMemberships;
+  total.checkedIn += carerCheckedIn;
+
+  const vatDivisor = 1 + ALVERSJO_VAT_RATE;
+  const exclVat = (n: number) => Math.round(n / vatDivisor);
+  const unitPriceExclVat = exclVat(input.alversjoPrice);
+  // Spring memberships only: fall was already invoiced gross at its full value.
+  const quantity = input.alversjoPrice
+    ? sales.spring.alversjoGross / input.alversjoPrice
+    : 0;
+  const linesExclVat = Math.round(quantity * unitPriceExclVat);
+  const refundExclVat = exclVat(sales.spring.alversjoRefunded);
+  // Both sales' fees: fall's were never deducted when fall was invoiced.
+  const feesInclVat = sales.fall.alversjoFee + sales.spring.alversjoFee;
+  const feesExclVat = exclVat(feesInclVat);
+  const subtotalExclVat = linesExclVat - refundExclVat - feesExclVat;
+  const vat = Math.round(subtotalExclVat * ALVERSJO_VAT_RATE);
+
+  const alversjoInvoice: AlversjoInvoice = {
+    quantity,
+    unitPriceExclVat,
+    linesExclVat,
+    refundedUnits: unitPriceExclVat ? refundExclVat / unitPriceExclVat : 0,
+    refundExclVat,
+    feesInclVat,
+    feesExclVat,
+    subtotalExclVat,
+    vat,
+    totalInclVat: subtotalExclVat + vat,
+  };
 
   return {
     currency: input.currency,
     fall: sales.fall,
     spring: sales.spring,
     total,
-    reconciliation: {
-      saleRowsNet,
-      unattributedPayments: {
-        count: unattributedCount,
-        amount: unattributedAmount,
-        net: unattributedNet,
-      },
-      disputes: {
-        count: disputeCount,
-        amount: disputeAmount,
-        fees: disputeFees,
-      },
-      otherBalanceTransactions: input.balanceSummary.other,
-      balanceNetExcludingPayouts: input.balanceSummary.netExcludingPayouts,
-      residual: input.balanceSummary.netExcludingPayouts - accountedFor,
-      payouts: input.balanceSummary.payouts,
-      unclassifiedMemberships,
-    },
+    carerMemberships,
+    alversjoInvoice,
     lastSyncedAt: input.lastSyncedAt,
   };
 }

--- a/utils/stripe/attribution.ts
+++ b/utils/stripe/attribution.ts
@@ -58,6 +58,10 @@ export function splitPayment(
         ? refund.amount
         : alversjoShare(refund.amount, alversjoGross, total);
   }
+  // Alversjö can never give back more than it received. A payment whose addon
+  // was refunded on its own and which was later transferred would otherwise be
+  // charged for the addon twice and go negative.
+  alversjoRefunded = Math.min(alversjoRefunded, alversjoGross);
   const baseRefunded = refundedTotal - alversjoRefunded;
 
   const alversjoDisputed = alversjoShare(

--- a/utils/stripe/types.ts
+++ b/utils/stripe/types.ts
@@ -40,8 +40,10 @@ export type PaymentSplit = {
   alversjoNet: number;
   baseFee: number;
   alversjoFee: number;
-  /** fee + fee_refunded + dispute_fee. */
+  /** fee + fee_refunded. */
   netFee: number;
+  /** Money the cardholder's bank took back, plus Stripe's dispute fee. */
+  chargeback: number;
 };
 
 export type SaleTotals = {
@@ -52,7 +54,10 @@ export type SaleTotals = {
   operatingIncome: number;
   /** Net of fee refunds, including dispute fees. */
   stripeFees: number;
-  netAfterFees: number;
+  /** Money taken back by cardholders, including Stripe's dispute fees. */
+  chargebacks: number;
+  /** operatingIncome − stripeFees − chargebacks. */
+  netKept: number;
   payments: number;
   refunds: number;
   transfers: number;

--- a/utils/stripe/types.ts
+++ b/utils/stripe/types.ts
@@ -65,6 +65,12 @@ export type SaleTotals = {
   memberships: number;
   /** How many of those memberships were checked in at the gate. */
   checkedIn: number;
+  /** Alversjö addon sold, before refunds. */
+  alversjoGross: number;
+  /** Alversjö's share of refunds, capped at what it received. */
+  alversjoRefunded: number;
+  /** Alversjö's share of Stripe fees, prorated by amount. */
+  alversjoFee: number;
   /**
    * What the burn gained (or lost) because these transfers happened, versus the
    * original holders simply keeping their memberships:
@@ -93,13 +99,26 @@ export type TransferInput = {
   at: string;
 };
 
-/** Account-wide totals for the reconciliation block. */
-export type BalanceSummary = {
-  /** Net across all balance transactions in the period, excluding payouts. */
-  netExcludingPayouts: number;
-  payouts: { count: number; amount: number };
-  /** Balance transactions that are neither charge, refund nor payout. */
-  other: { count: number; amount: number };
+/** Swedish VAT on the land membership supply. Does not vary. */
+export const ALVERSJO_VAT_RATE = 0.25;
+
+/**
+ * The invoice Alversjö sends BL for land memberships. Covers the spring
+ * memberships only - fall was already invoiced gross - but both sales' Stripe
+ * fees, because fall's were never deducted. All amounts in minor units.
+ */
+export type AlversjoInvoice = {
+  quantity: number;
+  unitPriceExclVat: number;
+  linesExclVat: number;
+  refundedUnits: number;
+  refundExclVat: number;
+  /** The real fee. Divided by 1 + VAT on the invoice so it comes off after VAT. */
+  feesInclVat: number;
+  feesExclVat: number;
+  subtotalExclVat: number;
+  vat: number;
+  totalInclVat: number;
 };
 
 export type FinancesPayload = {
@@ -107,22 +126,8 @@ export type FinancesPayload = {
   fall: SaleTotals;
   spring: SaleTotals;
   total: SaleTotals;
-  reconciliation: {
-    saleRowsNet: number;
-    /**
-     * Payments in the mirror belonging to another burn or with no resolvable
-     * purchase right. `amount` is gross; `net` is after their own refunds,
-     * disputes and fees, and is what the residual arithmetic uses.
-     */
-    unattributedPayments: { count: number; amount: number; net: number };
-    disputes: { count: number; amount: number; fees: number };
-    otherBalanceTransactions: { count: number; amount: number };
-    balanceNetExcludingPayouts: number;
-    /** balanceNetExcludingPayouts − everything accounted for above. Should be 0. */
-    residual: number;
-    payouts: { count: number; amount: number };
-    /** Memberships whose payment is not in the mirror, so cannot be dated. */
-    unclassifiedMemberships: number;
-  };
+  /** Free memberships with no Stripe payment, for carers. Counted in the total. */
+  carerMemberships: number;
+  alversjoInvoice: AlversjoInvoice;
   lastSyncedAt: string | null;
 };


### PR DESCRIPTION
Three things, all on the statistics page.

## Scoped to this burn

The reconciliation block is gone. Three of its five lines existed only to subtract things that were never BL 2026 — the 2025 burn's 6,037 payments, a pair of internal transfers netting to zero, and a "residual" that turned out to be a single Open Collective donation (`eric.reinford@gmail.com`, 2025-09-23, 2,000.00 less a 200.00 platform fee). Payments from another burn are now skipped rather than counted and then subtracted.

**Trade-off:** the page can no longer cross-check against total Stripe movement. An attribution mistake used to surface as a non-zero residual; now the numbers are internally consistent by construction. Accepted, because that check only meant something while the page pretended to describe the whole account.

## Money in, money out

| | Fall | Spring | Total |
|---|---|---|---|
| Operating income | 5,500,078.00 | 6,639,976.52 | 12,140,054.52 |
| Stripe fees | −96,783.65 | −146,627.86 | −243,411.51 |
| Chargebacks | 0.00 | −2,422.00 | −2,422.00 |
| **Net kept** | **5,403,294.35** | **6,490,926.66** | **11,894,221.01** |

Chargebacks were previously deducted silently *inside* operating income, which is why that figure read as unrelated to the rows around it. **Operating income is therefore 2,222.00 higher than the page showed before** and fees 200.00 lower — same money, nothing counted twice, `netKept` unchanged.

Carer memberships (free, no Stripe payment, for people supporting someone with a disability) now count in the total with their check-ins, so memberships read 5,443 rather than 5,438 and check-ins 4,937 rather than 4,933.

## Alversjö invoice

Christian rebuilds this by hand from a Stripe spreadsheet each time; his last pass used a flat 2% fee estimate that was 309 kr off. Now derived:

```
Land memberships   234,00 × 480,00  =  112 320,00
Refunds           −49,92 × 480,00  =  −23 961,60
Stripe fees        4 728,18 ÷ 1,25  =  − 3 782,54
                        Excl. VAT      84 575,86
                          VAT 25%      21 143,97
                            Total     105 719,83
```

Covers the **spring** memberships — fall was already invoiced gross at 112,800 — but **both** sales' Stripe fees, since fall's were never deducted. The fee line is divided by 1.25 so the full fee comes off after VAT, exactly how the 2025 invoice was built.

## A bug fixed along the way

Six payments had their 600 Alversjö addon refunded separately and were later transferred. The addon refund was attributed wholly to Alversjö **and** a proportional slice of the transfer refund was taken from Alversjö too — charging it twice and driving its net negative. Alversjö's share of refunds is now capped at what it received, with the excess falling to the base membership. **Alversjö was under-credited by 2,274.78 kr.**

An existing test asserted the old behaviour on this exact shape; it has been corrected rather than kept.

## Also

The route stops querying `stripe_balance_transactions` — ~14,500 rows per request that nothing uses now.

## Checks

57 tests · `tsc --noEmit` clean · build compiles · no new lint warnings. Every figure above is from production data, not fixtures.

Spec: `docs/superpowers/specs/2026-07-29-finances-bl2026-only-design.md` · Plan: `docs/superpowers/plans/2026-07-29-finances-bl2026-only.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)